### PR TITLE
Replace UID with address in UI

### DIFF
--- a/backend/app/routers/buildings.py
+++ b/backend/app/routers/buildings.py
@@ -138,6 +138,7 @@ def get_paginated_buildings_for_disaster(
         BuildingListItem(
             id=row["id"],
             uid=row["uid"],
+            address=row["address"],
             image_pair_id=row["image_pair_id"],
             xbd_id=row["xbd_id"],
             actual_damage=row["actual_damage"],

--- a/backend/app/schemas/buildings.py
+++ b/backend/app/schemas/buildings.py
@@ -69,6 +69,7 @@ class BuildingFeatureCollectionBboxOnly(BaseModel):
 class BuildingListItem(BaseModel):
     id: int
     uid: str
+    address: str | None = None
     image_pair_id: int
     xbd_id: int
     actual_damage: str

--- a/backend/app/services/buildings.py
+++ b/backend/app/services/buildings.py
@@ -135,6 +135,7 @@ def fetch_paginated_buildings_by_disaster(
     SELECT
       b.id,
       b.uid::text,
+      b.address,
       b.image_pair_id,
       ip.xbd_id,
       b.actual_damage::text,

--- a/frontend/src/components/features/BuildingPopup.tsx
+++ b/frontend/src/components/features/BuildingPopup.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 interface BuildingPopupProps {
 	uid: string;
+	address?: string;
 	predictedDamage?: string;
 	predictedDamageColor: string;
 	actualDamage?: string;
@@ -11,6 +12,7 @@ interface BuildingPopupProps {
 
 export function BuildingPopup({
 	uid,
+	address,
 	predictedDamage,
 	predictedDamageColor,
 	actualDamage,
@@ -26,16 +28,18 @@ export function BuildingPopup({
 		};
 	}, []);
 
-	const handleCopyUID = React.useCallback(async () => {
+	const copyText = address || uid;
+
+	const handleCopy = React.useCallback(async () => {
 		try {
-			await navigator.clipboard.writeText(uid);
+			await navigator.clipboard.writeText(copyText);
 			setCopied(true);
 			if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
 			copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
 		} catch (err) {
 			console.error("Failed to copy to clipboard:", err);
 		}
-	}, [uid]);
+	}, [copyText]);
 
 	return (
 		<div className="popup-card">
@@ -52,14 +56,14 @@ export function BuildingPopup({
 			</div>
 			<div className="popup-body">
 				<div className="popup-section">
-					<div className="popup-label">Building ID</div>
+					<div className="popup-label">Address</div>
 					<div className="popup-value-container">
-						<span className="popup-value">{uid.length > 0 ? uid : "—"}</span>
-						{uid.length > 0 && (
+						<span className="popup-value">{address || "—"}</span>
+						{address && (
 							<button
 								className="copy-btn"
-								onClick={handleCopyUID}
-								aria-label="Copy building ID"
+								onClick={handleCopy}
+								aria-label="Copy address"
 								type="button"
 							>
 								<svg
@@ -82,6 +86,9 @@ export function BuildingPopup({
 							</button>
 						)}
 					</div>
+					{uid.length > 0 && (
+						<div className="popup-uid-subfield">{uid}</div>
+					)}
 				</div>
 				<div className="popup-section">
 					<div className="popup-label">Predicted Damage</div>

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -483,6 +483,7 @@ export default function MapView({
 				>
 					<BuildingPopup
 						uid={popupData.uid}
+						address={popupData.address}
 						predictedDamage={popupData.predictedDamage}
 						predictedDamageColor={popupData.predictedDamageColor}
 						actualDamage={popupData.actualDamage}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -835,6 +835,15 @@ body {
 	display: block;
 }
 
+.popup-uid-subfield {
+	font-size: 10px;
+	color: var(--popup-muted, #94a3b8);
+	font-family: monospace;
+	margin-top: 2px;
+	word-break: break-all;
+	opacity: 0.7;
+}
+
 /* =========================
    COPY BUTTON
 ========================= */

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -399,7 +399,7 @@ export default function Dashboard() {
 					return {
 						id: prop.id,
 						uid: prop.uid,
-ttttttaddress: typeof prop.address === "string" ? prop.address : null,
+						address: typeof prop.address === "string" ? prop.address : null,
 						disaster_name: selectedDisasterName ?? "Unknown",
 						image_pair_id: prop.image_pair_id,
 						xbd_id: pair?.xbd_id ?? -1,

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -35,6 +35,7 @@ type NormalizedDamage = DamageLevel | "un-classified";
 type BuildingListItem = {
 	id: number;
 	uid: string;
+	address?: string | null;
 	image_pair_id: number;
 	xbd_id: number;
 	disaster_name: string;
@@ -398,6 +399,7 @@ export default function Dashboard() {
 					return {
 						id: prop.id,
 						uid: prop.uid,
+ttttttaddress: typeof prop.address === "string" ? prop.address : null,
 						disaster_name: selectedDisasterName ?? "Unknown",
 						image_pair_id: prop.image_pair_id,
 						xbd_id: pair?.xbd_id ?? -1,
@@ -834,9 +836,9 @@ export default function Dashboard() {
 																<Item
 																	imageSrc={thumbnail}
 																	imageAlt={`Building ${building.uid}`}
-																	title={building.uid}
-																	subtitle={`xBD: ${building.xbd_id}`}
-																	meta={`Image Pair ID: ${building.image_pair_id}`}
+																	title={building.address || building.uid}
+																	subtitle={building.address ? building.uid : `xBD: ${building.xbd_id}`}
+																	meta={building.address ? `xBD: ${building.xbd_id}` : `Image Pair ID: ${building.image_pair_id}`}
 																/>
 															</td>
 															<td className="py-3 pr-3 font-medium text-xs whitespace-nowrap">

--- a/frontend/src/utils/hazardlyApi.ts
+++ b/frontend/src/utils/hazardlyApi.ts
@@ -181,6 +181,7 @@ export interface BuildingStatsResponse {
 export interface PaginatedBuildingListItem {
 	id: number;
 	uid: string;
+	address?: string | null;
 	image_pair_id: number;
 	xbd_id: number;
 	actual_damage: string;

--- a/frontend/src/utils/hazardlyApi.ts
+++ b/frontend/src/utils/hazardlyApi.ts
@@ -135,6 +135,7 @@ export interface BuildingProperties {
 	id: number;
 	uid: string;
 	image_pair_id: number;
+	address?: string | null;
 	predicted_damage?: string;
 	actual_damage?: string;
 	is_correct?: boolean | null;

--- a/frontend/src/utils/mapViewSetup.ts
+++ b/frontend/src/utils/mapViewSetup.ts
@@ -26,6 +26,7 @@ const SATELLITE_FULL_OPACITY = 1;
 
 export interface PopupData {
 	uid: string;
+	address?: string;
 	predictedDamage?: string;
 	predictedDamageColor: string;
 	actualDamage?: string;
@@ -300,12 +301,14 @@ export function bindBuildingInteractions(params: {
 			{ selected: true },
 		);
 
+		const address = asString(feature.properties?.address);
 		const predictedDamage = asString(feature.properties?.predicted_damage);
 		const predictedDamageColor = getBuildingDamageColor(predictedDamage);
 		const actualDamage = asString(feature.properties?.actual_damage);
 		const actualDamageColor = getBuildingDamageColor(actualDamage);
 		onPopupOpen({
 			uid,
+			address,
 			predictedDamage,
 			predictedDamageColor,
 			actualDamage,


### PR DESCRIPTION
## Summary
- Building popups now show the address as the primary label with UID as a smaller subfield
- Dashboard buildings table shows address as the row title, UID drops to subtitle
- Added `address` to the paginated buildings endpoint (was missing)

Closes #36