### PR TITLE
Add chatbot routing payload and frontend implementation

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routers import buildings, disasters, image_pairs
+from app.routers import buildings, chat, disasters, image_pairs
 
 app = FastAPI(title="Hazardly API")
 
@@ -16,6 +16,7 @@ app.add_middleware(
 app.include_router(disasters.router)
 app.include_router(image_pairs.router)
 app.include_router(buildings.router)
+app.include_router(chat.router)
 
 
 @app.get("/")

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -92,19 +92,23 @@ def parse_question(question):
     else:
         damage = "major-damage"
 
-    # extract location if "near" exists
-    if "near" in q:
-        parts = q.split("near")
-        if len(parts) > 1:
-            address = parts[1].replace("?", "").strip()
+    # extract location from common location phrases
+    location_match = re.search(
+        r"\b(?:near|in)\s+(.+?)(?:\?|$)",
+        q,
+        flags=re.IGNORECASE,
+    )
 
-            for word in ["damage", "buildings", "area"]:
-                address = address.replace(word, "").strip()
+    if location_match:
+        address = location_match.group(1).strip()
 
-            # fix vague location like "me"
-            if address in ["me", "here", "my", "", "?"]:
-                address = "Houston Texas"
-        else:
+        for word in ["damage", "damaged", "buildings", "building", "area", "locations", "location"]:
+            address = re.sub(rf"\b{word}\b", "", address, flags=re.IGNORECASE).strip()
+
+        address = re.sub(r"\s+", " ", address).strip(" ,?")
+
+        # fix vague location like "me"
+        if address in ["me", "here", "my", "", "?"]:
             address = "Houston Texas"
 
     else:
@@ -145,6 +149,21 @@ def extract_address_filter_text(question):
     return None
 
 
+def extract_in_location_text(question):
+    match = re.search(r"\bin\s+(.+?)(?:\?|$)", question, flags=re.IGNORECASE)
+    if not match:
+        return None
+
+    address_text = match.group(1).strip(" ?,.")
+    address_text = re.sub(
+        r"\b(damage|damaged|buildings?|properties|records|locations?)\b",
+        "",
+        address_text,
+        flags=re.IGNORECASE,
+    ).strip(" ,")
+    return address_text or None
+
+
 
 
 # function to convert address → latitude/longitude using Mapbox API
@@ -173,12 +192,15 @@ def geocode_address(address):
     if len(data["features"]) == 0:
         return None
 
-    coords = data["features"][0]["center"]
+    feature = data["features"][0]
+    coords = feature["center"]
+    bbox = feature.get("bbox")
 
     return {
         "lon": coords[0],  # longitude
         "lat": coords[1],  # latitude
-        "formatted_address": data["features"][0]["place_name"]  # clean address
+        "formatted_address": feature["place_name"],  # clean address
+        "bbox": bbox,
     }
 
 
@@ -316,7 +338,7 @@ def get_all_buildings_near(lon, lat, radius_m):
     return rows_to_buildings(rows)  # converting SQL rows into frontend-friendly dictionaries
 
 
-def get_buildings_by_address_text(address_text, damage_filter):
+def get_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat, damage_filter):
     conn = get_db_connection()
     cur = conn.cursor()
 
@@ -324,12 +346,78 @@ def get_buildings_by_address_text(address_text, damage_filter):
     SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
     FROM buildings b
     JOIN image_pairs ip ON b.image_pair_id = ip.id
-    WHERE b.address IS NOT NULL
-      AND b.address ILIKE %s
-      AND b.predicted_damage = %s
+    WHERE b.predicted_damage = %s
+      AND ST_Intersects(
+        b.geom,
+        ST_MakeEnvelope(%s, %s, %s, %s, 4326)
+      )
     """
 
-    cur.execute(query, (f"%{address_text}%", damage_filter))
+    cur.execute(query, (damage_filter, min_lon, min_lat, max_lon, max_lat))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
+def get_all_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE ST_Intersects(
+        b.geom,
+        ST_MakeEnvelope(%s, %s, %s, %s, 4326)
+    )
+    """
+
+    cur.execute(query, (min_lon, min_lat, max_lon, max_lat))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
+def get_buildings_by_address_text(address_text, damage_filter):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    address_clean = address_text.strip()
+    address_parts = [part.strip() for part in address_clean.split(",") if part.strip()]
+    city_part = address_parts[0] if len(address_parts) > 0 else address_clean
+    region_part = address_parts[1] if len(address_parts) > 1 else None
+    region_aliases = {
+        "texas": ["texas", "tx"],
+    }
+    city_pattern = re.escape(city_part)
+    region_patterns = [
+        re.escape(alias)
+        for alias in region_aliases.get(region_part.lower(), [region_part])
+    ] if region_part else []
+    city_state_pattern = (
+        rf"\b{city_pattern}\b(?:\s*,\s*|\s+)(?:{'|'.join(region_patterns)})\b"
+        if region_patterns
+        else rf"\b{city_pattern}\b"
+    )
+
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE b.address IS NOT NULL
+      AND b.address ~* %s
+      AND b.predicted_damage = %s
+    """
+    params = [city_state_pattern, damage_filter]
+
+    cur.execute(query, tuple(params))
     rows = cur.fetchall()
 
     cur.close()
@@ -342,15 +430,34 @@ def get_all_buildings_by_address_text(address_text):
     conn = get_db_connection()
     cur = conn.cursor()
 
+    address_clean = address_text.strip()
+    address_parts = [part.strip() for part in address_clean.split(",") if part.strip()]
+    city_part = address_parts[0] if len(address_parts) > 0 else address_clean
+    region_part = address_parts[1] if len(address_parts) > 1 else None
+    region_aliases = {
+        "texas": ["texas", "tx"],
+    }
+    city_pattern = re.escape(city_part)
+    region_patterns = [
+        re.escape(alias)
+        for alias in region_aliases.get(region_part.lower(), [region_part])
+    ] if region_part else []
+    city_state_pattern = (
+        rf"\b{city_pattern}\b(?:\s*,\s*|\s+)(?:{'|'.join(region_patterns)})\b"
+        if region_patterns
+        else rf"\b{city_pattern}\b"
+    )
+
     query = """
     SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
     FROM buildings b
     JOIN image_pairs ip ON b.image_pair_id = ip.id
     WHERE b.address IS NOT NULL
-      AND b.address ILIKE %s
+      AND b.address ~* %s
     """
+    params = [city_state_pattern]
 
-    cur.execute(query, (f"%{address_text}%",))
+    cur.execute(query, tuple(params))
     rows = cur.fetchall()
 
     cur.close()
@@ -360,13 +467,7 @@ def get_all_buildings_by_address_text(address_text):
 
 
 def build_map_action_from_buildings(buildings, address_text=None):
-    xbd_ids = sorted({
-        b.get("xbd_id")
-        for b in buildings
-        if b.get("xbd_id") is not None
-    })
-
-    primary_xbd_id = xbd_ids[0] if len(xbd_ids) == 1 else (xbd_ids[0] if xbd_ids else None)
+    primary_xbd_id = get_primary_xbd_id(buildings)
 
     return {
         "type": "navigate",
@@ -380,6 +481,29 @@ def build_map_action_from_buildings(buildings, address_text=None):
             "building_ids": [b["uid"] for b in buildings],
         }
     }
+
+
+def get_primary_xbd_id(buildings):
+    xbd_counts = {}
+
+    for building in buildings:
+        xbd_id = building.get("xbd_id")
+        if xbd_id is None:
+            continue
+        xbd_counts[xbd_id] = xbd_counts.get(xbd_id, 0) + 1
+
+    if not xbd_counts:
+        return None
+
+    return max(sorted(xbd_counts), key=lambda xbd_id: xbd_counts[xbd_id])
+
+
+def get_buildings_for_primary_scene(buildings):
+    primary_xbd_id = get_primary_xbd_id(buildings)
+    if primary_xbd_id is None:
+        return []
+
+    return [b for b in buildings if b.get("xbd_id") == primary_xbd_id]
 
 
 
@@ -931,6 +1055,7 @@ def handle_chat_query(question):
     address_filter_text = extract_address_filter_text(question)
     if address_filter_text:
         buildings = get_buildings_by_address_text(address_filter_text, damage_type)
+        scene_buildings = get_buildings_for_primary_scene(buildings)
         geo = geocode_address(address_filter_text)
 
         if len(buildings) == 0:
@@ -969,7 +1094,64 @@ def handle_chat_query(question):
                 "lon": geo["lon"],
                 "address": geo["formatted_address"]
             } if geo else None,
-            "highlighted_buildings": buildings,
+            "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
+            "action": action
+        }
+
+    in_location_text = extract_in_location_text(question)
+    if in_location_text and "near" not in question.lower():
+        geo = geocode_address(in_location_text)
+        buildings = []
+        if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
+            min_lon, min_lat, max_lon, max_lat = geo["bbox"]
+            buildings = get_buildings_in_bbox(
+                min_lon,
+                min_lat,
+                max_lon,
+                max_lat,
+                damage_type,
+            )
+        if len(buildings) == 0:
+            buildings = get_buildings_by_address_text(in_location_text, damage_type)
+        scene_buildings = get_buildings_for_primary_scene(buildings)
+
+        if len(buildings) == 0:
+            answer = f"I could not find relevant damage data for {in_location_text}."
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": {
+                    "lat": geo["lat"],
+                    "lon": geo["lon"],
+                    "address": geo["formatted_address"]
+                } if geo else None,
+                "highlighted_buildings": [],
+                "action": build_no_action()
+            }
+
+        label_text = geo["formatted_address"] if geo else in_location_text
+        if damage_type == "no-damage":
+            answer = f"{len(buildings)} buildings in {label_text} appear to have no visible damage."
+        else:
+            answer = generate_llm_answer(buildings, label_text, damage_type)
+
+        action = (
+            build_building_action(buildings[0])
+            if len(buildings) == 1
+            else build_map_action_from_buildings(buildings, label_text)
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": {
+                "lat": geo["lat"],
+                "lon": geo["lon"],
+                "address": geo["formatted_address"]
+            } if geo else None,
+            "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
             "action": action
         }
 
@@ -983,6 +1165,8 @@ def handle_chat_query(question):
             b for b in all_buildings
             if b.get("damage") == damage_type
         ]
+        scene_all_buildings = get_buildings_for_primary_scene(all_buildings)
+        scene_filtered_buildings = get_buildings_for_primary_scene(filtered_buildings)
 
         if is_data_summary_query(question):
             counts = count_damage_levels(all_buildings)
@@ -996,7 +1180,7 @@ def handle_chat_query(question):
                 "answer": answer,
                 "response": answer,
                 "focus": None,
-                "highlighted_buildings": all_buildings,
+                "highlighted_buildings": scene_all_buildings,
                 "action": action,
             }
             save_turn(question, answer)
@@ -1015,7 +1199,7 @@ def handle_chat_query(question):
                 "answer": answer,
                 "response": answer,
                 "focus": None,
-                "highlighted_buildings": all_buildings,
+                "highlighted_buildings": scene_all_buildings,
                 "action": action,
             }
             save_turn(question, answer)
@@ -1047,7 +1231,7 @@ def handle_chat_query(question):
             "answer": answer,
             "response": answer,
             "focus": None,
-            "highlighted_buildings": filtered_buildings,
+            "highlighted_buildings": scene_filtered_buildings if len(filtered_buildings) > 1 else filtered_buildings,
             "action": action,
         }
         save_turn(question, answer)
@@ -1061,6 +1245,14 @@ def handle_chat_query(question):
             geo["lat"],
             5000
         )
+        used_address_fallback = len(all_buildings) == 0
+        if used_address_fallback:
+            all_buildings = get_all_buildings_by_address_text(address)
+        scene_all_buildings = (
+            get_buildings_for_primary_scene(all_buildings)
+            if used_address_fallback
+            else all_buildings
+        )
 
         counts = count_damage_levels(all_buildings)
 
@@ -1073,7 +1265,7 @@ def handle_chat_query(question):
         action = build_map_action(geo, all_buildings)
 
         # package chatbot answer, map focus, highlighted buildings, and navigation action
-        payload = build_map_payload(answer, geo, all_buildings, action)
+        payload = build_map_payload(answer, geo, scene_all_buildings, action)
 
         save_turn(question, answer)
         return payload
@@ -1087,6 +1279,14 @@ def handle_chat_query(question):
             geo["lat"],
             5000
         )
+        used_address_fallback = len(all_buildings) == 0
+        if used_address_fallback:
+            all_buildings = get_all_buildings_by_address_text(address)
+        scene_all_buildings = (
+            get_buildings_for_primary_scene(all_buildings)
+            if used_address_fallback
+            else all_buildings
+        )
 
         if len(all_buildings) == 0:
             answer = "I couldn’t find enough nearby damage data to give a reliable advisory for that area."
@@ -1098,7 +1298,7 @@ def handle_chat_query(question):
             action = build_map_action(geo, all_buildings)
 
         # package chatbot answer, map focus, highlighted buildings, and navigation action
-        payload = build_map_payload(answer, geo, all_buildings, action)
+        payload = build_map_payload(answer, geo, scene_all_buildings, action)
 
 
         save_turn(question, answer)
@@ -1110,6 +1310,14 @@ def handle_chat_query(question):
         geo["lat"],
         5000,
         damage_type
+    )
+    used_address_fallback = len(buildings) == 0
+    if used_address_fallback:
+        buildings = get_buildings_by_address_text(address, damage_type)
+    scene_buildings = (
+        get_buildings_for_primary_scene(buildings)
+        if used_address_fallback
+        else buildings
     )
 
     if len(buildings) == 0:
@@ -1141,7 +1349,7 @@ def handle_chat_query(question):
         action = build_map_action(geo, buildings)
 
     # package chatbot answer, map focus, highlighted buildings, and navigation action
-    payload = build_map_payload(answer, geo, buildings, action)
+    payload = build_map_payload(answer, geo, scene_buildings, action)
     save_turn(question, answer)
     return payload
 

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CHAT_SESSION_ID = "default"
 MAX_CHAT_HISTORY_MESSAGES = 40
+DEFAULT_NEMOTRON_MODEL = "mistralai/mistral-nemotron"
+DEFAULT_NEMOTRON_FALLBACK_MODEL = ""
 _active_chat_session_id = ContextVar(
     "active_chat_session_id",
     default=DEFAULT_CHAT_SESSION_ID,
@@ -767,6 +769,35 @@ def format_city_list_response(rows):
 
     sample = city_names[:12]
     return "Cities in the dataset are: " + ", ".join(sample) + "."
+
+
+def clean_city_list_response(answer, fallback, rows):
+    if not answer:
+        return fallback
+
+    city_names = [str(row[0]).strip() for row in rows if str(row[0]).strip()]
+    bad_phrases = [
+        "provided facts",
+        "following your rules",
+        "strictly adhere",
+        "plain list",
+        "here's a list",
+        "here is a list",
+    ]
+
+    for line in str(answer).splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        lower_candidate = candidate.lower()
+        if any(phrase in lower_candidate for phrase in bad_phrases):
+            continue
+        if candidate.startswith("[") or candidate.endswith("]"):
+            continue
+        if any(city.lower() in lower_candidate for city in city_names):
+            return candidate
+
+    return fallback
 
 
 def resolve_location_buildings(location_text):
@@ -1880,6 +1911,8 @@ def call_nemotron(prompt):
 
     url = os.getenv("NEMOTRON_URL")  # API endpoint
     api_key = os.getenv("NEMOTRON_API_KEY")  # API key
+    model = os.getenv("NEMOTRON_MODEL", DEFAULT_NEMOTRON_MODEL).strip() or DEFAULT_NEMOTRON_MODEL
+    fallback_model = os.getenv("NEMOTRON_FALLBACK_MODEL", DEFAULT_NEMOTRON_FALLBACK_MODEL).strip()
 
     # checking if config exists
     if not url or not api_key:
@@ -1896,27 +1929,40 @@ def call_nemotron(prompt):
         {"role": "user", "content": prompt}
     ]
 
-    payload = {
-        "model": "mistralai/mistral-nemotron",
-        "messages": messages,
-        "max_tokens": 300
-    }
+    models = [model]
+    if fallback_model and fallback_model not in models:
+        models.append(fallback_model)
 
-    try:
-        response = requests.post(url, headers=headers, json=payload, timeout=60)
-        response.raise_for_status()
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        if not isinstance(content, str):
-            return None
-        content = content.strip('"')
-        return content if content else None
-    except requests.RequestException as exc:
-        logger.warning("Nemotron request failed: %s", exc)
-        return None
-    except (KeyError, IndexError, TypeError, ValueError) as exc:
-        logger.warning("Nemotron response had an unexpected shape: %s", exc)
-        return None
+    for model_name in models:
+        payload = {
+            "model": model_name,
+            "messages": messages,
+            "max_tokens": 300
+        }
+
+        try:
+            response = requests.post(url, headers=headers, json=payload, timeout=60)
+            response.raise_for_status()
+            data = response.json()
+            content = data["choices"][0]["message"]["content"]
+            if not isinstance(content, str):
+                return None
+            content = content.strip('"')
+            return content if content else None
+        except requests.HTTPError as exc:
+            response_text = getattr(exc.response, "text", "")
+            logger.warning(
+                "Nemotron request failed for model %s: %s. Response: %s",
+                model_name,
+                exc,
+                response_text[:500],
+            )
+        except requests.RequestException as exc:
+            logger.warning("Nemotron request failed for model %s: %s", model_name, exc)
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            logger.warning("Nemotron response had an unexpected shape for model %s: %s", model_name, exc)
+
+    return None
 
 
 def synthesize_structured_answer(prompt, fallback_answer):
@@ -2927,21 +2973,32 @@ def format_city_damage_stats(rows):
 
 def synthesize_city_damage_stats_answer(rows):
     fallback = format_city_list_response(rows)
+    city_names = []
+    seen = set()
+    for row in rows:
+        city = str(row[0]).strip()
+        if not city or city.lower() in seen:
+            continue
+        seen.add(city.lower())
+        city_names.append(city)
+
     prompt = f"""
 You are Hazardly, a disaster damage assessment assistant.
 
-Use only these exact facts:
-City rows: {rows[:8]}
+The user asked which cities are in the active disaster dataset.
 
-Write a concise answer for the user.
+City names:
+{", ".join(city_names[:12])}
+
+Write one concise answer sentence.
 
 Rules:
-- Return a plain list of city names only.
-- Do not include damage counts or rankings.
-- Use a natural city-list intro sentence.
-- Do not invent extra places or numbers.
+- Mention the city names naturally in one sentence.
+- Do not include counts, rankings, brackets, bullets, or Python list syntax.
+- Do not mention prompts, rules, instructions, or provided facts.
+- Do not add a second answer or correction.
 """
-    return synthesize_structured_answer(prompt, fallback)
+    return clean_city_list_response(call_nemotron(prompt), fallback, rows)
 
 
 def summarize_damage_data(buildings, address):

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -3,6 +3,7 @@ import psycopg  # used to connect to PostgreSQL (Supabase)
 import requests  # used to make HTTP API calls (Mapbox + Nemotron)
 import os  # used to access environment variables
 import json  # used to convert GeoJSON text from PostGIS into a real Python dictionary
+import re
 from pathlib import Path
 from urllib.parse import quote  # used to safely encode values inside frontend route URLs
 from dotenv import load_dotenv  # used to load .env file
@@ -124,6 +125,26 @@ def parse_question(question):
     return address, damage
 
 
+def extract_address_filter_text(question):
+    q = question.strip()
+
+    patterns = [
+        r"have\s+an?\s+(.+?)\s+address",
+        r"with\s+an?\s+(.+?)\s+address",
+        r"in\s+(.+?)\s+by\s+address",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, q, flags=re.IGNORECASE)
+        if not match:
+            continue
+        address_text = match.group(1).strip(" ?,.")
+        address_text = re.sub(r"\b(buildings?|properties|records)\b", "", address_text, flags=re.IGNORECASE).strip(" ,")
+        return address_text or None
+
+    return None
+
+
 
 
 # function to convert address → latitude/longitude using Mapbox API
@@ -223,7 +244,7 @@ Keep it 1–2 sentences.
 
 """
      # calling Nemotron LLM to generate final answer
-    return call_nemotron(prompt)
+    return call_nemotron(prompt) or fallback_advisory_response(buildings, address)
 
 
 
@@ -293,6 +314,72 @@ def get_all_buildings_near(lon, lat, radius_m):
     conn.close()  # closing database connection
 
     return rows_to_buildings(rows)  # converting SQL rows into frontend-friendly dictionaries
+
+
+def get_buildings_by_address_text(address_text, damage_filter):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE b.address IS NOT NULL
+      AND b.address ILIKE %s
+      AND b.predicted_damage = %s
+    """
+
+    cur.execute(query, (f"%{address_text}%", damage_filter))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
+def get_all_buildings_by_address_text(address_text):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE b.address IS NOT NULL
+      AND b.address ILIKE %s
+    """
+
+    cur.execute(query, (f"%{address_text}%",))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
+def build_map_action_from_buildings(buildings, address_text=None):
+    xbd_ids = sorted({
+        b.get("xbd_id")
+        for b in buildings
+        if b.get("xbd_id") is not None
+    })
+
+    primary_xbd_id = xbd_ids[0] if len(xbd_ids) == 1 else (xbd_ids[0] if xbd_ids else None)
+
+    return {
+        "type": "navigate",
+        "target": "map",
+        "reason": "address_query" if address_text else "building_query",
+        "url": build_map_route(DEFAULT_DISASTER_NAME, primary_xbd_id),
+        "params": {
+            "disaster_name": DEFAULT_DISASTER_NAME,
+            "xbd_id": primary_xbd_id,
+            "address": address_text,
+            "building_ids": [b["uid"] for b in buildings],
+        }
+    }
 
 
 
@@ -495,7 +582,7 @@ def call_nemotron(prompt):
 
     # checking if config exists
     if not url or not api_key:
-        return "Nemotron not configured"
+        return None
 
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -514,14 +601,57 @@ def call_nemotron(prompt):
         "max_tokens": 300
     }
 
-    response = requests.post(url, headers=headers, json=payload)
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=30)
 
-    if response.status_code != 200:
-        return f"Error: {response.text}"
+        if response.status_code != 200:
+            return None
 
-    data = response.json()
+        data = response.json()
+        content = data["choices"][0]["message"]["content"].strip('"')
+        return content if content else None
+    except Exception:
+        return None
 
-    return data["choices"][0]["message"]["content"].strip('"')
+
+def fallback_damage_answer(total, address, damage_type):
+    clean_damage = damage_type.replace("-", " ")
+    building_label = "building" if total == 1 else "buildings"
+    return f"I found {total} {clean_damage} {building_label} near {address}."
+
+
+def fallback_advisory_response(buildings, address):
+    counts = count_damage_levels(buildings)
+    total = sum(counts.values())
+    severe_total = counts.get("major-damage", 0) + counts.get("destroyed", 0)
+
+    if total == 0:
+        return f"I couldn’t find enough nearby damage data to assess conditions around {address}."
+    if severe_total > 0:
+        return (
+            f"Damage near {address} includes {severe_total} severely affected buildings, "
+            "so responders should expect disrupted conditions and verify access before deployment."
+        )
+    return (
+        f"Damage near {address} appears limited in this dataset, but field conditions should still be "
+        "verified before making operational decisions."
+    )
+
+
+def fallback_damage_summary(buildings, address):
+    counts = count_damage_levels(buildings)
+    total = sum(counts.values())
+
+    if total == 0:
+        return f"I couldn’t find damage assessment data for {address}."
+
+    return (
+        f"For {address}, I found {total} buildings total: "
+        f"{counts.get('no-damage', 0)} no-damage, "
+        f"{counts.get('minor-damage', 0)} minor-damage, "
+        f"{counts.get('major-damage', 0)} major-damage, and "
+        f"{counts.get('destroyed', 0)} destroyed."
+    )
 
 
 
@@ -538,7 +668,7 @@ class NemotronLLM(CustomLLM):
         }
 
     def complete(self, prompt, **kwargs):
-        result = call_nemotron(prompt)
+        result = call_nemotron(prompt) or ""
         return CompletionResponse(text=result)
 
     def stream_complete(self, prompt, **kwargs):
@@ -577,7 +707,10 @@ Rules:
 - Sound professional and natural.
 """
 
-    return str(Settings.llm.complete(prompt)).strip('"').split(")*")[0]
+    result = str(Settings.llm.complete(prompt)).strip('"').split(")*")[0].strip()
+    if not result:
+        return fallback_damage_answer(total, address, damage_type)
+    return result
 
 
 def is_disaster_related(question):
@@ -685,7 +818,7 @@ Write a short, clear summary of the situation.
 Keep it 1–2 sentences.
 """
 
-    return call_nemotron(prompt)
+    return call_nemotron(prompt) or fallback_damage_summary(buildings, address)
 
 
 def summarize_conversation():
@@ -711,7 +844,16 @@ Write a short plain-English recap in 2-3 sentences.
 Do not use bullet points.
 """
 
-    return call_nemotron(prompt)
+    fallback_lines = [
+        m["content"]
+        for m in chat_history[-6:]
+        if m.get("content")
+    ]
+    fallback = " ".join(fallback_lines)[:280].strip()
+
+    return call_nemotron(prompt) or (
+        fallback if fallback else "No conversation to summarize yet."
+    )
 
 
 
@@ -784,21 +926,132 @@ def handle_chat_query(question):
             "action": build_no_action()  # full dataset does not navigate to one route
         }
 
+    _, damage_type = parse_question(question)
+
+    address_filter_text = extract_address_filter_text(question)
+    if address_filter_text:
+        buildings = get_buildings_by_address_text(address_filter_text, damage_type)
+        geo = geocode_address(address_filter_text)
+
+        if len(buildings) == 0:
+            answer = f"I could not find relevant damage data for addresses matching {address_filter_text}."
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": {
+                    "lat": geo["lat"],
+                    "lon": geo["lon"],
+                    "address": geo["formatted_address"]
+                } if geo else None,
+                "highlighted_buildings": [],
+                "action": build_no_action()
+            }
+
+        label_text = geo["formatted_address"] if geo else address_filter_text
+        if damage_type == "no-damage":
+            answer = f"{len(buildings)} buildings with addresses matching {label_text} appear to have no visible damage."
+        else:
+            answer = generate_llm_answer(buildings, label_text, damage_type)
+
+        action = (
+            build_building_action(buildings[0])
+            if len(buildings) == 1
+            else build_map_action_from_buildings(buildings, label_text)
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": {
+                "lat": geo["lat"],
+                "lon": geo["lon"],
+                "address": geo["formatted_address"]
+            } if geo else None,
+            "highlighted_buildings": buildings,
+            "action": action
+        }
 
     # location-based queries
     address, damage_type = parse_question(question)
     geo = geocode_address(address)
 
     if not geo:
-        answer = "Could not find that location. Try a different place."
-        save_turn(question, answer)
-        return {
+        all_buildings = get_all_buildings_by_address_text(address)
+        filtered_buildings = [
+            b for b in all_buildings
+            if b.get("damage") == damage_type
+        ]
+
+        if is_data_summary_query(question):
+            counts = count_damage_levels(all_buildings)
+            answer = format_damage_count_response(counts, address)
+            action = (
+                build_map_action_from_buildings(all_buildings, address)
+                if len(all_buildings) > 0
+                else build_no_action()
+            )
+            payload = {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": all_buildings,
+                "action": action,
+            }
+            save_turn(question, answer)
+            return payload
+
+        advisory = detect_advisory(question)
+        if advisory:
+            if len(all_buildings) == 0:
+                answer = f"I couldn’t find enough nearby damage data to give a reliable advisory for {address}."
+                action = build_no_action()
+            else:
+                answer = advisory_response(question, all_buildings, address)
+                action = build_map_action_from_buildings(all_buildings, address)
+
+            payload = {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": all_buildings,
+                "action": action,
+            }
+            save_turn(question, answer)
+            return payload
+
+        if len(filtered_buildings) == 0:
+            answer = "I could not find relevant damage data for that area. Try a different location."
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action()
+            }
+
+        if damage_type == "no-damage":
+            answer = f"{len(filtered_buildings)} buildings in {address} appear to have no visible damage."
+        else:
+            answer = generate_llm_answer(filtered_buildings, address, damage_type)
+
+        action = (
+            build_building_action(filtered_buildings[0])
+            if len(filtered_buildings) == 1
+            else build_map_action_from_buildings(filtered_buildings, address)
+        )
+
+        payload = {
             "answer": answer,
-            "response": answer,  # same text for frontend compatibility
+            "response": answer,
             "focus": None,
-            "highlighted_buildings": [],
-            "action": build_no_action()  # no route because location was not found
+            "highlighted_buildings": filtered_buildings,
+            "action": action,
         }
+        save_turn(question, answer)
+        return payload
 
 
     # city/street overall damage summary

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -1,9 +1,10 @@
 # importing libraries needed for database, API calls, and environment variables
+from contextvars import ContextVar
+import logging
 import psycopg  # used to connect to PostgreSQL (Supabase)
 import requests  # used to make HTTP API calls (Mapbox + Nemotron)
 import os  # used to access environment variables
 import json  # used to convert GeoJSON text from PostGIS into a real Python dictionary
-import random
 import re
 from pathlib import Path
 from urllib.parse import quote  # used to safely encode values inside frontend route URLs
@@ -15,24 +16,44 @@ from llama_index.core.llms import CustomLLM, CompletionResponse
 
 
 
-# storing conversation history for context
-chat_history = []
+logger = logging.getLogger(__name__)
 
-# storing conversation history for context
+
+DEFAULT_CHAT_SESSION_ID = "default"
+MAX_CHAT_HISTORY_MESSAGES = 40
+_active_chat_session_id = ContextVar(
+    "active_chat_session_id",
+    default=DEFAULT_CHAT_SESSION_ID,
+)
+chat_histories = {}
+
+
+def set_active_chat_session(session_id=None):
+    normalized_session_id = str(session_id or DEFAULT_CHAT_SESSION_ID).strip()
+    _active_chat_session_id.set(normalized_session_id or DEFAULT_CHAT_SESSION_ID)
+
+
+def get_chat_history():
+    session_id = _active_chat_session_id.get()
+    return chat_histories.setdefault(session_id, [])
+
+
 def save_turn(question, answer):
-    chat_history.append({"role": "user", "content": question})
-    chat_history.append({"role": "assistant", "content": answer})
+    history = get_chat_history()
+    history.append({"role": "user", "content": question})
+    history.append({"role": "assistant", "content": answer})
+    del history[:-MAX_CHAT_HISTORY_MESSAGES]
 
 
 def get_last_user_message():
-    for message in reversed(chat_history):
+    for message in reversed(get_chat_history()):
         if message.get("role") == "user":
             return message.get("content", "")
     return ""
 
 
 def get_last_assistant_message():
-    for message in reversed(chat_history):
+    for message in reversed(get_chat_history()):
         if message.get("role") == "assistant":
             return message.get("content", "")
     return ""
@@ -106,6 +127,20 @@ DAMAGE_LABEL_TEXT = {
     "destroyed": "destroyed",
 }
 
+# Radius (meters) for point-in-area building lookups in conversational queries,
+# including "damage near X" proximity searches.
+NEARBY_SEARCH_RADIUS_METERS = 5000
+
+# Canonical damage labels matching the database `damage_level` enum.
+DAMAGE_LEVELS = ("no-damage", "minor-damage", "major-damage", "destroyed")
+
+
+def format_radius_label(radius_m):
+    if radius_m >= 1000:
+        km = radius_m / 1000
+        return f"{km:g} km"
+    return f"{radius_m} m"
+
 
 # function to connect to database using environment variables
 def get_db_connection():
@@ -166,7 +201,7 @@ def parse_question(question):
     elif "destroyed" in q:
         damage = "destroyed"
     else:
-        damage = "major-damage"
+        damage = None
 
     # extract location from common location phrases
     location_match = re.search(
@@ -190,17 +225,8 @@ def parse_question(question):
     else:
         address = None
 
-        # try to get location from chat history
-        for msg in reversed(chat_history):
-            content = msg.get("content", "").lower()
-
-            if "houston" in content:
-                address = "Houston Texas"
-                break
-
-        # final fallback
-        if not address:
-            address = "Houston Texas"
+    if address is not None and not str(address).strip():
+        address = None
 
     return address, damage
 
@@ -376,37 +402,49 @@ def looks_like_exact_address(location_text):
 
 def geocode_address(address):
 
-    api_key = os.getenv("MAPBOX_API_KEY")  # getting API key
+    if address is None or not str(address).strip():
+        return None
 
-    # building Mapbox API URL
-    url = f"https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json"
+    api_key = os.getenv("MAPBOX_API_KEY") # getting API key
+    if not api_key:
+        return None
+
+    # Mapbox expects the query segment URL-encoded (spaces, commas, etc.).
+    encoded = quote(str(address).strip(), safe="")
+    url = f"https://api.mapbox.com/geocoding/v5/mapbox.places/{encoded}.json"
 
     params = {
         "access_token": api_key,
         "limit": 1  # only need top result
     }
 
-    # sending request to Mapbox
-    response = requests.get(url, params=params)
-
-    # if API fails, return None
-    if response.status_code != 200:
+    try:
+        # sending request to Mapbox
+        response = requests.get(url, timeout=15, params=params)
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError):
         return None
-
-    data = response.json()
 
     # if no results found
-    if len(data["features"]) == 0:
+    features = data.get("features") or []
+    if len(features) == 0:
         return None
 
-    feature = data["features"][0]
-    coords = feature["center"]
+    feature = features[0]
+    if not isinstance(feature, dict):
+        return None
+
+    coords = feature.get("center", [])
+    if not isinstance(coords, (list, tuple)) or len(coords) < 2:
+        return None
+
     bbox = feature.get("bbox")
 
     return {
         "lon": coords[0],  # longitude
         "lat": coords[1],  # latitude
-        "formatted_address": feature["place_name"],  # clean address
+        "formatted_address": feature.get("place_name", str(address).strip()),  # clean address
         "bbox": bbox,
     }
 
@@ -659,13 +697,16 @@ def fetch_scene_stats(limit=None):
       COALESCE(SUM(CASE WHEN b.predicted_damage = 'destroyed' THEN 1 ELSE 0 END), 0) AS destroyed,
       COALESCE(SUM(CASE
         WHEN b.predicted_damage IS NOT NULL
+         AND b.actual_damage IS NOT NULL
          AND b.actual_damage::text = b.predicted_damage::text
         THEN 1 ELSE 0 END), 0) AS correct_count,
       COALESCE(SUM(CASE
         WHEN b.predicted_damage IS NOT NULL
+         AND b.actual_damage IS NOT NULL
         THEN 1 ELSE 0 END), 0) AS compared_count,
       COALESCE(SUM(CASE
         WHEN b.predicted_damage IS NOT NULL
+         AND b.actual_damage IS NOT NULL
          AND b.actual_damage::text <> b.predicted_damage::text
         THEN 1 ELSE 0 END), 0) AS incorrect_count
     FROM image_pairs ip
@@ -1193,12 +1234,12 @@ def normalize_street_query_parts(address_text):
 
 
 def get_buildings_on_address_text(address_text, damage_filter=None):
-    conn = get_db_connection()
-    cur = conn.cursor()
-
     address_parts = normalize_street_query_parts(address_text)
     if not address_parts:
         return []
+
+    conn = get_db_connection()
+    cur = conn.cursor()
 
     street_part = address_parts[0]
     street_core = re.sub(
@@ -1226,39 +1267,40 @@ def get_buildings_on_address_text(address_text, damage_filter=None):
         strict_query += " AND b.predicted_damage = %s"
         strict_params.append(damage_filter)
 
-    cur.execute(strict_query, tuple(strict_params))
-    rows = cur.fetchall()
-
-    if len(rows) == 0:
-        relaxed_query = base_query
-        relaxed_params = []
-
-        if street_core:
-            relaxed_query += " AND b.address ILIKE %s"
-            relaxed_params.append(f"%{street_core}%")
-        else:
-            relaxed_query += " AND b.address ILIKE %s"
-            relaxed_params.append(f"%{street_part}%")
-
-        if city_part:
-            relaxed_query += " AND b.address ILIKE %s"
-            relaxed_params.append(f"%{city_part}%")
-
-        for part in state_or_zip_parts:
-            if re.fullmatch(r"\d{5}", part):
-                continue
-            relaxed_query += " AND b.address ILIKE %s"
-            relaxed_params.append(f"%{part}%")
-
-        if damage_filter:
-            relaxed_query += " AND b.predicted_damage = %s"
-            relaxed_params.append(damage_filter)
-
-        cur.execute(relaxed_query, tuple(relaxed_params))
+    try:
+        cur.execute(strict_query, tuple(strict_params))
         rows = cur.fetchall()
 
-    cur.close()
-    conn.close()
+        if len(rows) == 0:
+            relaxed_query = base_query
+            relaxed_params = []
+
+            if street_core:
+                relaxed_query += " AND b.address ILIKE %s"
+                relaxed_params.append(f"%{street_core}%")
+            else:
+                relaxed_query += " AND b.address ILIKE %s"
+                relaxed_params.append(f"%{street_part}%")
+
+            if city_part:
+                relaxed_query += " AND b.address ILIKE %s"
+                relaxed_params.append(f"%{city_part}%")
+
+            for part in state_or_zip_parts:
+                if re.fullmatch(r"\d{5}", part):
+                    continue
+                relaxed_query += " AND b.address ILIKE %s"
+                relaxed_params.append(f"%{part}%")
+
+            if damage_filter:
+                relaxed_query += " AND b.predicted_damage = %s"
+                relaxed_params.append(damage_filter)
+
+            cur.execute(relaxed_query, tuple(relaxed_params))
+            rows = cur.fetchall()
+    finally:
+        cur.close()
+        conn.close()
 
     return rows_to_buildings(rows)
 
@@ -1358,10 +1400,7 @@ def get_all_misclassified_buildings():
     return rows_to_buildings(rows)
 
 
-def get_buildings_by_address_text(address_text, damage_filter):
-    conn = get_db_connection()
-    cur = conn.cursor()
-
+def build_address_city_pattern(address_text):
     address_clean = address_text.strip()
     address_parts = [part.strip() for part in address_clean.split(",") if part.strip()]
     city_part = address_parts[0] if len(address_parts) > 0 else address_clean
@@ -1383,52 +1422,13 @@ def get_buildings_by_address_text(address_text, damage_filter):
         if region_patterns
         else rf"\b{city_pattern}\b"
     )
-
-    query = """
-    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
-    FROM buildings b
-    JOIN image_pairs ip ON b.image_pair_id = ip.id
-    WHERE b.address IS NOT NULL
-      AND b.address ~* %s
-      AND b.predicted_damage = %s
-    """
-    params = [city_state_pattern, damage_filter]
-
-    cur.execute(query, tuple(params))
-    rows = cur.fetchall()
-
-    cur.close()
-    conn.close()
-
-    return rows_to_buildings(rows)
+    return city_state_pattern
 
 
-def get_all_buildings_by_address_text(address_text):
+def query_buildings_by_address_text(address_text, damage_filter=None):
+    city_state_pattern = build_address_city_pattern(address_text)
     conn = get_db_connection()
     cur = conn.cursor()
-
-    address_clean = address_text.strip()
-    address_parts = [part.strip() for part in address_clean.split(",") if part.strip()]
-    city_part = address_parts[0] if len(address_parts) > 0 else address_clean
-    region_part = address_parts[1] if len(address_parts) > 1 else None
-    region_aliases: dict[str, list[str]] = {
-        "texas": ["texas", "tx"],
-    }
-    city_pattern = re.escape(city_part)
-    region_values: list[str] = []
-    if region_part:
-        normalized_region_part = str(region_part)
-        region_values = region_aliases.get(
-            normalized_region_part.lower(),
-            [normalized_region_part],
-        )
-    region_patterns = [re.escape(alias) for alias in region_values]
-    city_state_pattern = (
-        rf"\b{city_pattern}\b(?:\s*,\s*|\s+)(?:{'|'.join(region_patterns)})\b"
-        if region_patterns
-        else rf"\b{city_pattern}\b"
-    )
-
     query = """
     SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
     FROM buildings b
@@ -1438,13 +1438,26 @@ def get_all_buildings_by_address_text(address_text):
     """
     params = [city_state_pattern]
 
-    cur.execute(query, tuple(params))
-    rows = cur.fetchall()
+    if damage_filter:
+        query += " AND b.predicted_damage = %s"
+        params.append(damage_filter)
 
-    cur.close()
-    conn.close()
+    try:
+        cur.execute(query, tuple(params))
+        rows = cur.fetchall()
+    finally:
+        cur.close()
+        conn.close()
 
     return rows_to_buildings(rows)
+
+
+def get_buildings_by_address_text(address_text, damage_filter):
+    return query_buildings_by_address_text(address_text, damage_filter)
+
+
+def get_all_buildings_by_address_text(address_text):
+    return query_buildings_by_address_text(address_text)
 
 
 def get_all_buildings_for_city(city_text):
@@ -1524,16 +1537,7 @@ def build_scene_action(xbd_id, building_ids=None, label_text=None):
 
 
 def get_primary_xbd_id(buildings):
-    xbd_ids = sorted({
-        building.get("xbd_id")
-        for building in buildings
-        if building.get("xbd_id") is not None
-    })
-
-    if not xbd_ids:
-        return None
-
-    return random.choice(xbd_ids)
+    return get_dominant_xbd_id(buildings)
 
 
 def get_dominant_xbd_id(buildings):
@@ -1610,12 +1614,7 @@ def get_full_dataset_damage_counts():
     cur.close()
     conn.close()
 
-    counts = {
-        "no-damage": 0,
-        "minor-damage": 0,
-        "major-damage": 0,
-        "destroyed": 0
-    }
+    counts = {level: 0 for level in DAMAGE_LEVELS}
 
     for damage, count in rows:
         if damage in counts:
@@ -1625,12 +1624,7 @@ def get_full_dataset_damage_counts():
 
 
 def count_damage_levels(buildings):
-    counts = {
-        "no-damage": 0,
-        "minor-damage": 0,
-        "major-damage": 0,
-        "destroyed": 0
-    }
+    counts = {level: 0 for level in DAMAGE_LEVELS}
 
     for b in buildings:
         damage = b["damage"]
@@ -1645,22 +1639,12 @@ def format_damage_count_response(counts, location_text):
     if total == 0:
         return f"I couldn't find damage assessment data for {location_text}."
 
-    known_total = (
-        counts.get("no-damage", 0)
-        + counts.get("minor-damage", 0)
-        + counts.get("major-damage", 0)
-        + counts.get("destroyed", 0)
-    )
-
+    known_total = sum(counts.get(level, 0) for level in DAMAGE_LEVELS)
     other_total = total - known_total
 
-    response = (
-        f"For {location_text}, I found {total} buildings total: "
-        f"{counts.get('no-damage', 0)} no-damage, "
-        f"{counts.get('minor-damage', 0)} minor-damage, "
-        f"{counts.get('major-damage', 0)} major-damage, and "
-        f"{counts.get('destroyed', 0)} destroyed"
-    )
+    parts = [f"{counts.get(level, 0)} {level}" for level in DAMAGE_LEVELS]
+    parts[-1] = "and " + parts[-1]
+    response = f"For {location_text}, I found {total} buildings total: " + ", ".join(parts)
 
     if other_total > 0:
         response += f", with {other_total} other or unlabeled records"
@@ -1846,15 +1830,19 @@ def call_nemotron(prompt):
     }
 
     try:
-        response = requests.post(url, headers=headers, json=payload, timeout=30)
-
-        if response.status_code != 200:
-            return None
-
+        response = requests.post(url, headers=headers, json=payload, timeout=60)
+        response.raise_for_status()
         data = response.json()
-        content = data["choices"][0]["message"]["content"].strip('"')
+        content = data["choices"][0]["message"]["content"]
+        if not isinstance(content, str):
+            return None
+        content = content.strip('"')
         return content if content else None
-    except Exception:
+    except requests.RequestException as exc:
+        logger.warning("Nemotron request failed: %s", exc)
+        return None
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        logger.warning("Nemotron response had an unexpected shape: %s", exc)
         return None
 
 
@@ -1889,24 +1877,6 @@ def fallback_advisory_response(buildings, address):
         f"Damage near {address} appears limited in this dataset, but field conditions should still be "
         "verified before making operational decisions."
     )
-
-
-def fallback_damage_summary(buildings, address):
-    counts = count_damage_levels(buildings)
-    total = sum(counts.values())
-
-    if total == 0:
-        return f"I couldn't find damage assessment data for {address}."
-
-    return (
-        f"For {address}, I found {total} buildings total: "
-        f"{counts.get('no-damage', 0)} no-damage, "
-        f"{counts.get('minor-damage', 0)} minor-damage, "
-        f"{counts.get('major-damage', 0)} major-damage, and "
-        f"{counts.get('destroyed', 0)} destroyed."
-    )
-
-
 
 
 # creating custom LLM wrapper for llamaindex
@@ -1953,6 +1923,38 @@ Number of buildings: {total}
 Write one short, clear sentence for the user.
 
 Rules:
+- Do NOT mention VLM, model, prediction data, database, SQL, backend, or LLM.
+- Do NOT change the number.
+- Do NOT add extra numbers.
+- Sound professional and natural.
+"""
+
+    result = str(Settings.llm.complete(prompt)).strip('"').split(")*")[0].strip()
+    if not result:
+        return fallback_damage_answer(total, address, damage_type)
+    return result
+
+
+def generate_proximity_llm_answer(buildings, address, damage_type, radius_m):
+    total = len(buildings)
+    clean_damage = damage_type.replace("-", " ")
+    radius_label = format_radius_label(radius_m)
+
+    prompt = f"""
+You are Hazardly, a disaster damage assessment chatbot.
+
+Use the exact facts below:
+Search center: {address}
+Search radius: {radius_label}
+Damage type: {clean_damage}
+Number of buildings: {total}
+
+Write one short, clear sentence telling the user how many {clean_damage} buildings
+were found NEAR (within the search radius around) {address}.
+
+Rules:
+- Phrase the result as buildings "near" or "around" the location.
+- Do NOT say the buildings are "on" or "at" {address}; they are nearby, not necessarily on that exact street.
 - Do NOT mention VLM, model, prediction data, database, SQL, backend, or LLM.
 - Do NOT change the number.
 - Do NOT add extra numbers.
@@ -2600,6 +2602,7 @@ def parse_structured_query(question):
         question,
         flags=re.IGNORECASE,
     )
+    has_near_keyword = bool(re.search(r"\bnear\b", question, flags=re.IGNORECASE))
 
     locations = []
     query_mode = "generic_location"
@@ -2643,6 +2646,12 @@ def parse_structured_query(question):
         primary_location = format_scene_label(explicit_scene_id)
         locations = [primary_location]
         query_mode = "scene"
+    elif has_near_keyword and parsed_address:
+        # "near X" implies a radius/proximity search around X, not an
+        # exact-address ILIKE match on building.address.
+        primary_location = normalize_location_candidate(parsed_address)
+        locations = [primary_location] if primary_location else []
+        query_mode = "proximity"
     else:
         primary_location = (
             normalize_location_candidate(parsed_address)
@@ -2652,8 +2661,10 @@ def parse_structured_query(question):
         locations = [primary_location] if primary_location else []
 
     damage_filter = extract_damage_filter(question)
+    has_explicit_damage_filter = damage_filter is not None
     if damage_filter is None and inherited_damage_filter is not None:
         damage_filter = inherited_damage_filter
+        has_explicit_damage_filter = True
     if mapped_intent == "location_query" and damage_filter is None:
         damage_filter = parsed_default_damage
     if mapped_intent in {"location_overview", "city_list", "city_count"}:
@@ -2703,7 +2714,13 @@ def parse_structured_query(question):
         "wants_all_buildings": (
             inherited_damage_filter is None
             if dataset_scope_followup and query_mode == "dataset_scope_followup"
-            else is_all_buildings_query(question)
+            else (
+                is_all_buildings_query(question)
+                or (
+                    mapped_intent == "location_query"
+                    and not has_explicit_damage_filter
+                )
+            )
         ),
         "advisory": detect_advisory(question),
         "query_mode": query_mode,
@@ -2712,50 +2729,8 @@ def parse_structured_query(question):
     }
 
 
-def format_city_damage_stats(rows):
-    if len(rows) == 0:
-        return "I couldn't find any city-level address data in the dataset."
-
-    summary_parts = []
-    for row in rows[:8]:
-        city = row[0]
-        total = row[1]
-        destroyed = row[5]
-        major = row[4]
-        summary_parts.append(
-            f"{city} ({total} total, {major} major-damage, {destroyed} destroyed)"
-        )
-
-    return "Cities in the dataset include: " + "; ".join(summary_parts) + "."
-
-def summarize_damage_data(buildings, address):
-
-    counts = {}
-
-    for b in buildings:
-        d = b["damage"]
-        counts[d] = counts.get(d, 0) + 1
-
-    prompt = f"""
-You are summarizing disaster damage data.
-
-Location: {address}
-Damage breakdown: {counts}
-
-Write a short, clear summary of the situation.
-
-- Do NOT say "assistant"
-- Do NOT refer to yourself
-- Speak directly
-- Describe severity and impact
-
-Keep it 1–2 sentences.
-"""
-
-    return call_nemotron(prompt) or fallback_damage_summary(buildings, address)
-
-
 def summarize_conversation():
+    chat_history = get_chat_history()
 
     if len(chat_history) == 0:
         return "No conversation to summarize yet."
@@ -2865,7 +2840,8 @@ Keep it concise.
 #   payload["answer"] -> chatbot message
 #   payload["focus"] -> map zoom/pan location
 #   payload["highlighted_buildings"] -> building polygons to highlight
-def handle_chat_query(question):
+def handle_chat_query(question, session_id=None):
+    set_active_chat_session(session_id)
     question = question.strip()
 
     if not question:
@@ -3421,6 +3397,130 @@ def handle_chat_query(question):
             "action": action
         }
 
+    if (
+        intent == "location_query"
+        and parsed_query["query_mode"] == "proximity"
+        and primary_location
+        and not advisory
+        and not parsed_query["wants_summary"]
+    ):
+        # "damage near X" -> true radius search around the geocoded center of X.
+        # We deliberately skip resolve_location_buildings here because that helper
+        # does an ILIKE match on building.address for exact-looking inputs, which
+        # would return only buildings literally on that street and lose the
+        # "nearby scene" context the user is asking for.
+        # Advisory and summary queries fall through to the generic handler below
+        # because that path already does its own radius search and adds the
+        # correct advisory/summary reasoning on top.
+        proximity_location_text = primary_location
+        geo = geocode_address(proximity_location_text)
+
+        if not geo:
+            answer = (
+                f"I couldn't find a location to search around for "
+                f"{proximity_location_text}."
+            )
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
+
+        radius_m = NEARBY_SEARCH_RADIUS_METERS
+
+        label_text = geo["formatted_address"]
+
+        if wants_all_buildings:
+            buildings = get_all_buildings_near(geo["lon"], geo["lat"], radius_m)
+        else:
+            buildings = get_buildings_near(
+                geo["lon"], geo["lat"], radius_m, damage_type
+            )
+
+        primary_xbd_id = get_dominant_xbd_id(buildings)
+        scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
+
+        focus = {
+            "lat": geo["lat"],
+            "lon": geo["lon"],
+            "address": label_text,
+        }
+
+        if len(buildings) == 0:
+            all_nearby = get_all_buildings_near(geo["lon"], geo["lat"], radius_m)
+
+            if not all_nearby:
+                radius_label = format_radius_label(radius_m)
+                answer = (
+                    f"No assessed buildings appear in our database within about "
+                    f"{radius_label} of {label_text}."
+                )
+                save_turn(question, answer)
+                return {
+                    "answer": answer,
+                    "response": answer,
+                    "focus": None,
+                    "highlighted_buildings": [],
+                    "action": build_no_action(),
+                }
+
+            counts = count_damage_levels(all_nearby)
+            label = damage_type.replace("-", " ")
+            answer = (
+                f"Near {label_text}, no buildings are classified as {label}. "
+                + format_damage_count_response(counts, "that area")
+            )
+            nearby_primary_xbd_id = get_dominant_xbd_id(all_nearby)
+            nearby_scene_buildings = get_buildings_for_primary_scene(
+                all_nearby, nearby_primary_xbd_id
+            )
+            action = build_map_action_from_buildings(
+                all_nearby, label_text, nearby_primary_xbd_id
+            )
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": focus,
+                "highlighted_buildings": nearby_scene_buildings,
+                "action": action,
+            }
+
+        if wants_all_buildings:
+            counts = count_damage_levels(buildings)
+            answer = synthesize_location_overview_answer(
+                f"near {label_text}", counts
+            )
+        elif damage_type == "no-damage":
+            answer = (
+                f"{len(buildings)} buildings near {label_text} appear to have "
+                "no visible damage."
+            )
+        else:
+            answer = generate_proximity_llm_answer(
+                buildings, label_text, damage_type, radius_m
+            )
+
+        action = (
+            build_building_action(buildings[0])
+            if len(buildings) == 1
+            else build_map_action_from_buildings(
+                buildings, label_text, primary_xbd_id
+            )
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": focus,
+            "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
+            "action": action,
+        }
+
     # generic location-based queries
     address = primary_location
     if not address:
@@ -3522,13 +3622,24 @@ def handle_chat_query(question):
         all_buildings = get_all_buildings_near(
             geo["lon"],
             geo["lat"],
-            5000
+            NEARBY_SEARCH_RADIUS_METERS,
         )
         used_address_fallback = len(all_buildings) == 0
         if used_address_fallback:
             all_buildings = get_all_buildings_by_address_text(address)
         primary_all_xbd_id = get_nearest_xbd_id(all_buildings)
         scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
+
+        if len(all_buildings) == 0:
+            answer = format_damage_count_response({}, geo["formatted_address"])
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
 
         counts = count_damage_levels(all_buildings)
 
@@ -3551,7 +3662,7 @@ def handle_chat_query(question):
         all_buildings = get_all_buildings_near(
             geo["lon"],
             geo["lat"],
-            5000
+            NEARBY_SEARCH_RADIUS_METERS,
         )
         used_address_fallback = len(all_buildings) == 0
         if used_address_fallback:
@@ -3561,7 +3672,14 @@ def handle_chat_query(question):
 
         if len(all_buildings) == 0:
             answer = "I couldn't find enough nearby damage data to give a reliable advisory for that area."
-            action = build_no_action()
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
         else:
             answer = advisory_response(question, all_buildings, geo["formatted_address"])
 
@@ -3592,9 +3710,14 @@ def handle_chat_query(question):
             map_geo = geo
             location_label = geo["formatted_address"]
 
-    # exact damage count queries should count from the full resolved location set,
-    # then choose one representative scene only for map visualization.
-    buildings = filter_buildings_by_damage(all_buildings, damage_type)
+    # Exact damage count queries should count from the full resolved location set,
+    # then choose one representative scene only for map visualization. If the
+    # user did not name a damage class, keep the full location set.
+    buildings = (
+        all_buildings
+        if wants_all_buildings
+        else filter_buildings_by_damage(all_buildings, damage_type)
+    )
     primary_buildings_xbd_id = (
         get_primary_xbd_id(buildings)
         if len(buildings) > 0
@@ -3606,21 +3729,58 @@ def handle_chat_query(question):
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
 
     if len(buildings) == 0:
-        answer = "I could not find relevant damage data for that area. Try a different location."
-        save_turn(question, answer)
-        return {
-            "answer": answer,  # chatbot response text
-            "response": answer,  # same text for frontend compatibility
-            "focus": {
-                "lat": map_geo["lat"],  # latitude of the searched location
-                "lon": map_geo["lon"],  # longitude of the searched location
-                "address": map_geo["formatted_address"]  # readable searched address
-            },
-            "highlighted_buildings": [],  # no buildings matched
-            "action": build_no_action()  # no navigation target because no building was found
-        }
+        all_nearby = get_all_buildings_near(
+            geo["lon"],
+            geo["lat"],
+            NEARBY_SEARCH_RADIUS_METERS,
+        )
+        radius_label = format_radius_label(NEARBY_SEARCH_RADIUS_METERS)
+        label = damage_type.replace("-", " ")
+        if not all_nearby:
+            answer = (
+                f"No assessed buildings appear in our database within about {radius_label} of "
+                f"{geo['formatted_address']}. "
+                "The dataset imagery may not cover this spot, or the search radius may be too small."
+            )
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
 
-    if damage_type == "no-damage":
+        nearby_primary_xbd_id = get_dominant_xbd_id(all_nearby)
+        nearby_scene_buildings = get_buildings_for_primary_scene(
+            all_nearby,
+            nearby_primary_xbd_id,
+        )
+        action = build_map_action_from_buildings(
+            all_nearby,
+            geo["formatted_address"],
+            nearby_primary_xbd_id,
+        )
+        counts = count_damage_levels(all_nearby)
+        if wants_all_buildings:
+            answer = synthesize_location_overview_answer(
+                f"within about {radius_label} of {geo['formatted_address']}",
+                counts,
+            )
+        else:
+            answer = (
+                f"Within about {radius_label} of {geo['formatted_address']}, no buildings are classified as "
+                f"{label}. "
+                + format_damage_count_response(counts, "that radius")
+            )
+        payload = build_map_payload(answer, geo, nearby_scene_buildings, action)
+        save_turn(question, answer)
+        return payload
+
+    if wants_all_buildings:
+        counts = count_damage_levels(buildings)
+        answer = synthesize_location_overview_answer(location_label, counts)
+    elif damage_type == "no-damage":
         answer = f"{len(buildings)} buildings in {location_label} appear to have no visible damage."
     else:
         answer = generate_llm_answer(buildings, location_label, damage_type)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -2410,6 +2410,13 @@ def is_untrained_disaster_request(question):
 def classify_query_intent_heuristic(question):
     lowered_question = question.lower()
 
+    if (
+        any(phrase in lowered_question for phrase in ["how many", "count"])
+        and extract_damage_filter(question) is not None
+        and re.search(r"\b(?:near|in|on|around|at)\b", lowered_question)
+    ):
+        return "location_query"
+
     if is_scope_clarification_prompt(question):
         return "unsupported"
 

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -40,11 +40,38 @@ def get_last_assistant_message():
 
 def is_dataset_scope_followup(question):
     normalized_question = question.strip().lower()
-    if normalized_question not in {"full", "full dataset", "dataset", "all"}:
+    if normalized_question not in {
+        "full",
+        "full dataset",
+        "dataset",
+        "all",
+        "entire dataset",
+        "the entire dataset",
+        "whole dataset",
+        "entire data",
+        "the entire data",
+        "whole data",
+    }:
         return False
 
     last_assistant_message = get_last_assistant_message().lower()
     return "full dataset, or for a specific city or area" in last_assistant_message
+
+
+def is_location_scope_followup(question):
+    normalized_question = question.strip().lower()
+    if not normalized_question:
+        return False
+    if normalized_question in {"full", "full dataset", "dataset", "all"}:
+        return False
+
+    last_assistant_message = get_last_assistant_message().lower()
+    return "full dataset, or for a specific city or area" in last_assistant_message
+
+
+def is_scope_clarification_prompt(question):
+    normalized_question = re.sub(r"\s+", " ", question.strip().lower()).strip(" ?.")
+    return normalized_question == "do you want those results for the full dataset, or for a specific city or area"
 
 # loading environment variables from backend/.env file so secrets are not hardcoded
 BACKEND_DIR = Path(__file__).resolve().parent.parent
@@ -183,6 +210,12 @@ def extract_in_location_text(question):
 
     address_text = match.group(1).strip(" ?,.")
     address_text = re.sub(
+        r"\s+(?:that\s+have|that\s+has|with|showing)\s+.+$",
+        "",
+        address_text,
+        flags=re.IGNORECASE,
+    ).strip(" ,")
+    address_text = re.sub(
         r"\b(damage|damaged|buildings?|properties|records|locations?)\b",
         "",
         address_text,
@@ -221,17 +254,50 @@ def extract_general_location_text(question):
             continue
         location_text = match.group(1).strip(" ?,.")
         location_text = re.sub(
+            r"^(?:buildings?|properties|records)\s+",
+            "",
+            location_text,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
+        location_text = re.sub(
             r"\b(damage|damaged|buildings?|properties|records|stats|statistics|information)\b",
             "",
             location_text,
             flags=re.IGNORECASE,
         ).strip(" ,")
         location_text = re.sub(
+            r"^(?:that\s+have|that\s+has|with|showing)\s+",
+            "",
+            location_text,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
+        location_text = re.sub(r"[-\s]+", " ", location_text).strip(" ,.-")
+        location_text = re.sub(
             r"^(?:the\s+)?city\s+of\s+",
             "",
             location_text,
             flags=re.IGNORECASE,
         ).strip(" ,")
+        if not location_text:
+            return None
+        if location_text.lower() in {
+            "no",
+            "non",
+            "undamaged",
+            "unaffected",
+            "destroyed",
+            "major",
+            "minor",
+            "that have minor",
+            "that have major",
+            "that have destroyed",
+            "that have no",
+            "have minor",
+            "have major",
+            "have destroyed",
+            "have no",
+        }:
+            return None
         return location_text or None
 
     return None
@@ -1611,6 +1677,7 @@ def is_disaster_related(question):
     keywords = [
         # damage + building
         "damage", "building", "structure", "collapse", "destruction", "minor", "major", "destroyed",
+        "undamaged", "non-damaged", "non damaged", "no damage", "no-damage",
 
         # disaster types
         "disaster", "hurricane", "flood", "earthquake", "storm", "harvey", "natural disaster",
@@ -1739,6 +1806,11 @@ def is_damage_label_query(question):
 
 
 def classify_query_intent_heuristic(question):
+    lowered_question = question.lower()
+
+    if is_scope_clarification_prompt(question):
+        return "unsupported"
+
     if is_vlm_query(question):
         return "vlm"
 
@@ -1769,6 +1841,24 @@ def classify_query_intent_heuristic(question):
 
     if extract_xbd_query_id(question) is not None:
         return "xbd_query"
+
+    if (
+        "tell me about" in lowered_question
+        and "building" in lowered_question
+        and extract_damage_filter(question) is not None
+        and (
+            extract_in_location_text(question)
+            or extract_on_location_text(question)
+            or "near " in lowered_question
+            or (
+                not extract_general_location_text(question)
+                and "near " not in lowered_question
+                and " in " not in lowered_question
+                and " on " not in lowered_question
+            )
+        )
+    ):
+        return "location_query"
 
     if extract_general_location_text(question):
         return "general_location_overview"
@@ -1867,11 +1957,16 @@ def classify_query_intent(question):
     normalized_question = question.strip().lower()
     if is_dataset_scope_followup(question):
         last_user_message = get_last_user_message().lower()
+        inherited_damage_filter = extract_damage_filter(last_user_message)
         if any(term in last_user_message for term in ["show", "open", "take me", "go to"]):
-            inherited_damage_filter = extract_damage_filter(last_user_message)
             if inherited_damage_filter or "building" in last_user_message:
                 return "location_query"
+        if inherited_damage_filter or "building" in last_user_message:
             return "full_dataset_summary"
+    if is_location_scope_followup(question):
+        last_user_message = get_last_user_message().lower()
+        if extract_damage_filter(last_user_message) or "building" in last_user_message:
+            return "location_query"
 
     heuristic_intent = classify_query_intent_heuristic(question)
     if heuristic_intent:
@@ -1890,7 +1985,8 @@ def classify_query_intent(question):
 def extract_damage_filter(question):
     q = question.lower()
     if any(word in q for word in [
-        "fine", "no damage", "no-damage", "no damaged", "undamaged", "unaffected"
+        "fine", "no damage", "no-damage", "no damaged", "undamaged", "unaffected",
+        "non-damaged", "non damaged", "not damaged"
     ]):
         return "no-damage"
     if "minor" in q:
@@ -1915,6 +2011,21 @@ def normalize_location_candidate(location_text):
     ).strip(" ,")
     normalized = re.sub(r"\s+", " ", normalized).strip(" ,")
     return normalized or None
+
+
+def format_location_label(location_text):
+    if not location_text:
+        return location_text
+
+    normalized = re.sub(r"\s+", " ", str(location_text)).strip(" ,")
+    if not normalized:
+        return normalized
+
+    if normalized == normalized.lower():
+        parts = [part.strip() for part in normalized.split(",")]
+        return ", ".join(part.title() for part in parts if part)
+
+    return normalized
 
 
 def infer_scope(location_text, explicit_scene_id=None):
@@ -1951,10 +2062,15 @@ def parse_structured_query(question):
 
     explicit_scene_id = extract_xbd_query_id(question)
     dataset_scope_followup = is_dataset_scope_followup(question)
-    inherited_user_message = get_last_user_message() if dataset_scope_followup else ""
+    location_scope_followup = is_location_scope_followup(question)
+    inherited_user_message = (
+        get_last_user_message()
+        if (dataset_scope_followup or location_scope_followup)
+        else ""
+    )
     inherited_damage_filter = (
         extract_damage_filter(inherited_user_message)
-        if dataset_scope_followup
+        if (dataset_scope_followup or location_scope_followup)
         else None
     )
     comparison_locations = extract_comparison_locations(question)
@@ -1984,6 +2100,10 @@ def parse_structured_query(question):
 
     if dataset_scope_followup and mapped_intent == "location_query":
         query_mode = "dataset_scope_followup"
+    elif location_scope_followup and mapped_intent == "location_query":
+        primary_location = normalize_location_candidate(question)
+        locations = [primary_location] if primary_location else []
+        query_mode = "clarified_location"
     elif mapped_intent == "location_comparison" and comparison_locations:
         first_location = normalize_location_candidate(comparison_locations[0])
         second_location = normalize_location_candidate(comparison_locations[1])
@@ -2027,8 +2147,10 @@ def parse_structured_query(question):
         damage_filter = inherited_damage_filter
     if mapped_intent == "location_query" and damage_filter is None:
         damage_filter = parsed_default_damage
-    if mapped_intent in {"location_overview", "dataset_overview", "city_list", "city_count"}:
+    if mapped_intent in {"location_overview", "city_list", "city_count"}:
         damage_filter = None
+    if mapped_intent == "location_overview" and primary_location is None and damage_filter is not None:
+        mapped_intent = "dataset_overview"
 
     wants_navigation = any(
         phrase in question.lower()
@@ -2396,7 +2518,10 @@ def handle_chat_query(question):
         }
 
     if intent == "unsupported":
-        answer = "I can only answer disaster-related queries about damage, safety, and assessments."
+        if is_scope_clarification_prompt(question):
+            answer = "Please answer with either the full dataset or a specific city or area."
+        else:
+            answer = "I can only answer disaster-related queries about damage, safety, and assessments."
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -2409,7 +2534,19 @@ def handle_chat_query(question):
     # full dataset summary does not have a single map focus
     if intent == "dataset_overview":
         counts = get_full_dataset_damage_counts()
-        answer = synthesize_location_overview_answer("the full dataset", counts)
+        if damage_type and damage_type in counts:
+            damage_label = {
+                "no-damage": "undamaged",
+                "minor-damage": "minor-damage",
+                "major-damage": "major-damage",
+                "destroyed": "destroyed",
+            }[damage_type]
+            answer = "\n".join([
+                f"Here's the dataset summary for {damage_label} buildings:",
+                f"- Total {damage_label} buildings: {counts.get(damage_type, 0)}",
+            ])
+        else:
+            answer = synthesize_location_overview_answer("the full dataset", counts)
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -2621,7 +2758,10 @@ def handle_chat_query(question):
     # generic location-based queries
     address = primary_location
     if not address:
-        if intent == "location_query" and parsed_query["needs_map"]:
+        if (
+            (intent == "location_query" and (parsed_query["needs_map"] or parsed_query["damage_filter"]))
+            or (intent == "location_overview" and parsed_query["damage_filter"] and not primary_location)
+        ):
             answer = (
                 "Do you want those results for the full dataset, or for a specific city or area?"
             )
@@ -2639,6 +2779,7 @@ def handle_chat_query(question):
     geo = geocode_address(address)
 
     if not geo:
+        display_address = format_location_label(address)
         all_buildings = get_all_buildings_by_address_text(address)
         filtered_buildings = [
             b for b in all_buildings
@@ -2651,9 +2792,9 @@ def handle_chat_query(question):
 
         if parsed_query["wants_summary"]:
             counts = count_damage_levels(all_buildings)
-            answer = format_damage_count_response(counts, address)
+            answer = format_damage_count_response(counts, display_address)
             action = (
-                build_map_action_from_buildings(all_buildings, address, primary_all_xbd_id)
+                build_map_action_from_buildings(all_buildings, display_address, primary_all_xbd_id)
                 if len(all_buildings) > 0
                 else build_no_action()
             )
@@ -2669,11 +2810,11 @@ def handle_chat_query(question):
 
         if advisory:
             if len(all_buildings) == 0:
-                answer = f"I couldn't find enough nearby damage data to give a reliable advisory for {address}."
+                answer = f"I couldn't find enough nearby damage data to give a reliable advisory for {display_address}."
                 action = build_no_action()
             else:
-                answer = advisory_response(question, all_buildings, address)
-                action = build_map_action_from_buildings(all_buildings, address, primary_all_xbd_id)
+                answer = advisory_response(question, all_buildings, display_address)
+                action = build_map_action_from_buildings(all_buildings, display_address, primary_all_xbd_id)
 
             payload = {
                 "answer": answer,
@@ -2697,14 +2838,14 @@ def handle_chat_query(question):
             }
 
         if damage_type == "no-damage":
-            answer = f"{len(filtered_buildings)} buildings in {address} appear to have no visible damage."
+            answer = f"{len(filtered_buildings)} buildings in {display_address} appear to have no visible damage."
         else:
-            answer = generate_llm_answer(filtered_buildings, address, damage_type)
+            answer = generate_llm_answer(filtered_buildings, display_address, damage_type)
 
         action = (
             build_building_action(filtered_buildings[0])
             if len(filtered_buildings) == 1
-            else build_map_action_from_buildings(filtered_buildings, address, primary_filtered_xbd_id)
+            else build_map_action_from_buildings(filtered_buildings, display_address, primary_filtered_xbd_id)
         )
 
         payload = {

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -445,6 +445,205 @@ def fetch_city_damage_stats(limit=20):
     return rows
 
 
+def resolve_location_buildings(location_text):
+    normalized_location = location_text.strip()
+    has_explicit_region = "," in normalized_location
+    geocode_query = normalized_location
+
+    if not has_explicit_region:
+        buildings = get_all_buildings_by_address_text(normalized_location)
+        if len(buildings) > 0:
+            return None, normalized_location, buildings
+        if DEFAULT_DISASTER_NAME == "hurricane-harvey":
+            geocode_query = f"{normalized_location}, Texas"
+
+    geo = geocode_address(geocode_query)
+    buildings = []
+
+    if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
+        min_lon, min_lat, max_lon, max_lat = geo["bbox"]
+        buildings = get_all_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat)
+
+    if len(buildings) == 0:
+        buildings = get_all_buildings_by_address_text(normalized_location)
+
+    if len(buildings) > 0 and not has_explicit_region:
+        label_text = normalized_location
+    else:
+        label_text = geo["formatted_address"] if geo else normalized_location
+
+    return geo, label_text, buildings
+
+
+def filter_buildings_by_damage(buildings, damage_type):
+    return [b for b in buildings if b.get("damage") == damage_type]
+
+
+def extract_percentage_location_text(question):
+    patterns = [
+        r"percentage of\s+(.+?)\s+buildings",
+        r"share of\s+(.+?)\s+buildings",
+        r"what percentage of\s+(.+?)\s+is",
+        r"what percent of\s+(.+?)\s+is",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, question, flags=re.IGNORECASE)
+        if not match:
+            continue
+        location_text = match.group(1).strip(" ?,.")
+        return location_text or None
+
+    return None
+
+
+def extract_comparison_locations(question):
+    patterns = [
+        r"compare\s+(.+?)\s+and\s+(.+?)(?:\?|$)",
+        r"compare\s+(.+?)\s+to\s+(.+?)(?:\?|$)",
+        r"which is worse,\s+(.+?)\s+or\s+(.+?)(?:\?|$)",
+        r"which is worse:\s+(.+?)\s+or\s+(.+?)(?:\?|$)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, question, flags=re.IGNORECASE)
+        if not match:
+            continue
+        first = match.group(1).strip(" ?,.")
+        second = match.group(2).strip(" ?,.")
+        if first and second:
+            return first, second
+
+    return None
+
+
+def is_city_comparison_query(question):
+    q = question.lower()
+    return "compare " in q or "which is worse" in q
+
+
+def is_city_ranking_query(question):
+    q = question.lower()
+    ranking_signals = [
+        "top ",
+        "most ",
+        "least ",
+        "hardest-hit",
+        "hardest hit",
+        "hit hardest",
+        "where is major damage concentrated",
+        "which cities have",
+        "what areas have",
+    ]
+    return any(signal in q for signal in ranking_signals)
+
+
+def extract_top_n(question, default=5):
+    match = re.search(r"\btop\s+(\d+)\b", question, flags=re.IGNORECASE)
+    if not match:
+        return default
+    try:
+        return max(1, min(int(match.group(1)), 10))
+    except ValueError:
+        return default
+
+
+def get_ranking_metric(question):
+    q = question.lower()
+    if any(term in q for term in ["destroyed", "hardest-hit", "hardest hit", "hit hardest"]):
+        return "destroyed"
+    if "major" in q:
+        return "major-damage"
+    if "minor" in q:
+        return "minor-damage"
+    if any(term in q for term in ["no damage", "no-damage", "undamaged", "least damage"]):
+        return "no-damage"
+    return "total"
+
+
+def sort_city_rows(rows, metric):
+    metric_index = {
+        "total": 1,
+        "no-damage": 2,
+        "minor-damage": 3,
+        "major-damage": 4,
+        "destroyed": 5,
+    }[metric]
+    return sorted(rows, key=lambda row: (-row[metric_index], row[0]))
+
+
+def format_city_ranking(rows, metric, limit):
+    if len(rows) == 0:
+        return "I couldn't find any city-level data for the active disaster dataset."
+
+    sorted_rows = sort_city_rows(rows, metric)[:limit]
+    metric_label = {
+        "total": "total buildings",
+        "no-damage": "no-damage buildings",
+        "minor-damage": "minor-damage buildings",
+        "major-damage": "major-damage buildings",
+        "destroyed": "destroyed buildings",
+    }[metric]
+
+    lines = [f"Top cities by {metric_label}:"]
+    for row in sorted_rows:
+        city = row[0]
+        value = row[{ "total": 1, "no-damage": 2, "minor-damage": 3, "major-damage": 4, "destroyed": 5 }[metric]]
+        total = row[1]
+        lines.append(f"- {city}: {value} {metric_label}, {total} total")
+
+    return "\n".join(lines)
+
+
+def format_percentage_response(location_text, damage_type, total, matching_total):
+    if total == 0:
+        return f"I couldn't find damage assessment data for {location_text}."
+
+    percentage = round((matching_total / total) * 100, 1)
+    damage_label = damage_type.replace("-", " ")
+
+    lines = [
+        f"Here's the percentage breakdown for {location_text}:",
+        f"- Total buildings: {total}",
+        f"- {damage_label.title()}: {matching_total}",
+        f"- Share of total: {percentage}%",
+    ]
+    return "\n".join(lines)
+
+
+def format_location_comparison(first_label, first_buildings, second_label, second_buildings):
+    first_counts = count_damage_levels(first_buildings)
+    second_counts = count_damage_levels(second_buildings)
+    first_total = sum(first_counts.values())
+    second_total = sum(second_counts.values())
+    first_severe = first_counts.get("major-damage", 0) + first_counts.get("destroyed", 0)
+    second_severe = second_counts.get("major-damage", 0) + second_counts.get("destroyed", 0)
+
+    if first_total == 0 and second_total == 0:
+        return "I couldn't find damage assessment data for either location."
+
+    if first_total == 0:
+        return f"I couldn't find damage assessment data for {first_label}, but I did for {second_label}."
+
+    if second_total == 0:
+        return f"I couldn't find damage assessment data for {second_label}, but I did for {first_label}."
+
+    if first_severe > second_severe:
+        worse_line = f"- Higher severe-damage load: {first_label}"
+    elif second_severe > first_severe:
+        worse_line = f"- Higher severe-damage load: {second_label}"
+    else:
+        worse_line = "- Higher severe-damage load: tied"
+
+    lines = [
+        f"Comparison of {first_label} and {second_label}:",
+        f"- {first_label}: {first_total} total, {first_counts.get('major-damage', 0)} major-damage, {first_counts.get('destroyed', 0)} destroyed",
+        f"- {second_label}: {second_total} total, {second_counts.get('major-damage', 0)} major-damage, {second_counts.get('destroyed', 0)} destroyed",
+        worse_line,
+    ]
+    return "\n".join(lines)
+
+
 def get_buildings_by_address_text(address_text, damage_filter):
     conn = get_db_connection()
     cur = conn.cursor()
@@ -1035,6 +1234,27 @@ def is_city_list_query(question):
     ])
 
 
+def is_city_count_query(question):
+    q = question.lower()
+    return any(k in q for k in [
+        "how many cities are represented",
+        "how many cities are in the data",
+        "how many cities are in the dataset",
+        "how many locations are in the data",
+        "how many locations are in the dataset",
+    ])
+
+
+def is_damage_label_query(question):
+    q = question.lower()
+    return any(k in q for k in [
+        "what kinds of damage labels exist",
+        "what damage labels exist",
+        "what damage levels exist",
+        "what labels are in the dataset",
+    ])
+
+
 def format_city_damage_stats(rows):
     if len(rows) == 0:
         return "I couldn't find any city-level address data in the dataset."
@@ -1206,6 +1426,38 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
 
+    if is_city_count_query(question):
+        rows = fetch_city_damage_stats(limit=500)
+        city_total = len(rows)
+        answer = (
+            f"The active disaster dataset includes {city_total} cities or named locations with address data."
+        )
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
+    if is_damage_label_query(question):
+        answer = "\n".join([
+            "The dataset uses these damage labels:",
+            "- No damage",
+            "- Minor damage",
+            "- Major damage",
+            "- Destroyed",
+        ])
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
     if is_city_list_query(question):
         rows = fetch_city_damage_stats()
         answer = format_city_damage_stats(rows)
@@ -1218,20 +1470,66 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
+    if is_city_ranking_query(question):
+        rows = fetch_city_damage_stats()
+        answer = format_city_ranking(
+            rows,
+            get_ranking_metric(question),
+            extract_top_n(question),
+        )
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
+    comparison_locations = extract_comparison_locations(question)
+    if comparison_locations and is_city_comparison_query(question):
+        first_location, second_location = comparison_locations
+        first_geo, first_label, first_buildings = resolve_location_buildings(first_location)
+        second_geo, second_label, second_buildings = resolve_location_buildings(second_location)
+
+        answer = format_location_comparison(
+            first_label,
+            first_buildings,
+            second_label,
+            second_buildings,
+        )
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
+    percentage_location_text = extract_percentage_location_text(question)
+    if percentage_location_text:
+        _, damage_type = parse_question(question)
+        geo, label_text, all_buildings = resolve_location_buildings(percentage_location_text)
+        matching_buildings = filter_buildings_by_damage(all_buildings, damage_type)
+        answer = format_percentage_response(
+            label_text,
+            damage_type,
+            len(all_buildings),
+            len(matching_buildings),
+        )
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
     general_location_text = extract_general_location_text(question)
     if general_location_text:
-        geo = geocode_address(general_location_text)
-        all_buildings = []
-        if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
-            min_lon, min_lat, max_lon, max_lat = geo["bbox"]
-            all_buildings = get_all_buildings_in_bbox(
-                min_lon,
-                min_lat,
-                max_lon,
-                max_lat,
-            )
-        if len(all_buildings) == 0:
-            all_buildings = get_all_buildings_by_address_text(general_location_text)
+        geo, label_text, all_buildings = resolve_location_buildings(general_location_text)
 
         if len(all_buildings) == 0:
             answer = f"I could not find relevant damage data for {general_location_text}."
@@ -1244,8 +1542,6 @@ def handle_chat_query(question):
                 "action": build_no_action(),
             }
 
-        primary_xbd_id = get_primary_xbd_id(all_buildings)
-        label_text = geo["formatted_address"] if geo else general_location_text
         counts = count_damage_levels(all_buildings)
         answer = format_damage_bullet_summary(counts, label_text)
 

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -85,6 +85,26 @@ DEFAULT_DISASTER_NAME = os.getenv("DEFAULT_DISASTER_NAME", "hurricane-harvey")
 STREET_ADDRESS_OVERVIEW_RADIUS_M = 300
 EXACT_ADDRESS_OVERVIEW_RADIUS_M = 75
 NAMED_LOCATION_OVERVIEW_RADIUS_M = 5000
+CITY_METRIC_INDEX = {
+    "total": 1,
+    "no-damage": 2,
+    "minor-damage": 3,
+    "major-damage": 4,
+    "destroyed": 5,
+}
+CITY_METRIC_LABEL = {
+    "total": "total buildings",
+    "no-damage": "undamaged buildings",
+    "minor-damage": "minorly damaged buildings",
+    "major-damage": "majorly damaged buildings",
+    "destroyed": "destroyed buildings",
+}
+DAMAGE_LABEL_TEXT = {
+    "no-damage": "undamaged",
+    "minor-damage": "minor-damage",
+    "major-damage": "major-damage",
+    "destroyed": "destroyed",
+}
 
 
 # function to connect to database using environment variables
@@ -1017,13 +1037,7 @@ def get_top_scene_for_metric(rows, metric):
 
 
 def sort_city_rows(rows, metric):
-    metric_index = {
-        "total": 1,
-        "no-damage": 2,
-        "minor-damage": 3,
-        "major-damage": 4,
-        "destroyed": 5,
-    }[metric]
+    metric_index = CITY_METRIC_INDEX[metric]
     return sorted(rows, key=lambda row: (-row[metric_index], row[0]))
 
 
@@ -1033,13 +1047,8 @@ def format_city_ranking(rows, metric, limit):
 
     sorted_rows = sort_city_rows(rows, metric)
     limited_rows = sorted_rows[:limit]
-    metric_label = {
-        "total": "total buildings",
-        "no-damage": "undamaged buildings",
-        "minor-damage": "minorly damaged buildings",
-        "major-damage": "majorly damaged buildings",
-        "destroyed": "destroyed buildings",
-    }[metric]
+    metric_index = CITY_METRIC_INDEX[metric]
+    metric_label = CITY_METRIC_LABEL[metric]
 
     header = (
         f"Cities in the dataset by {metric_label}:"
@@ -1050,7 +1059,7 @@ def format_city_ranking(rows, metric, limit):
     lines = [header]
     for row in limited_rows:
         city = row[0]
-        value = row[{ "total": 1, "no-damage": 2, "minor-damage": 3, "major-damage": 4, "destroyed": 5 }[metric]]
+        value = row[metric_index]
         total = row[1]
         lines.append(f"- {city}: {value} {metric_label}, {total} total")
 
@@ -2512,6 +2521,12 @@ def format_location_label(location_text):
     return normalized
 
 
+def get_damage_label_text(damage_type):
+    if not isinstance(damage_type, str):
+        return None
+    return DAMAGE_LABEL_TEXT.get(damage_type)
+
+
 def infer_scope(location_text, explicit_scene_id=None):
     if explicit_scene_id is not None:
         return "scene"
@@ -3189,16 +3204,12 @@ def handle_chat_query(question):
     # full dataset summary does not have a single map focus
     if intent == "dataset_overview":
         counts = get_full_dataset_damage_counts()
-        if damage_type and damage_type in counts:
-            damage_label = {
-                "no-damage": "undamaged",
-                "minor-damage": "minor-damage",
-                "major-damage": "major-damage",
-                "destroyed": "destroyed",
-            }[damage_type]
+        damage_key = damage_type if isinstance(damage_type, str) else None
+        damage_label = get_damage_label_text(damage_key)
+        if damage_key and damage_label and damage_key in counts:
             answer = "\n".join([
                 f"Here's the dataset summary for {damage_label} buildings:",
-                f"- Total {damage_label} buildings: {counts.get(damage_type, 0)}",
+                f"- Total {damage_label} buildings: {counts.get(damage_key, 0)}",
             ])
         else:
             answer = synthesize_location_overview_answer("the full dataset", counts)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -165,6 +165,21 @@ def extract_in_location_text(question):
     return address_text or None
 
 
+def extract_on_location_text(question):
+    match = re.search(r"\bon\s+(.+?)(?:\?|$)", question, flags=re.IGNORECASE)
+    if not match:
+        return None
+
+    address_text = match.group(1).strip(" ?,.")
+    address_text = re.sub(
+        r"\b(damage|damaged|buildings?|properties|records|locations?)\b",
+        "",
+        address_text,
+        flags=re.IGNORECASE,
+    ).strip(" ,")
+    return address_text or None
+
+
 def extract_general_location_text(question):
     patterns = [
         r"tell me about\s+(.+?)(?:\?|$)",
@@ -318,10 +333,14 @@ def get_buildings_near(lon, lat, radius_m, damage_filter):
         %s
     )
     AND b.predicted_damage = %s
+    ORDER BY ST_Distance(
+        b.geom::geography,
+        ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography
+    ) ASC
     """
 
     # executing query safely using parameters
-    cur.execute(query, (lon, lat, radius_m, damage_filter))
+    cur.execute(query, (lon, lat, radius_m, damage_filter, lon, lat))
 
     rows = cur.fetchall()  # getting all matching building rows
 
@@ -353,9 +372,13 @@ def get_all_buildings_near(lon, lat, radius_m):
         ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
         %s
     )
+    ORDER BY ST_Distance(
+        b.geom::geography,
+        ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography
+    ) ASC
     """
 
-    cur.execute(query, (lon, lat, radius_m))  # safely passing lon, lat, and radius into SQL
+    cur.execute(query, (lon, lat, radius_m, lon, lat))  # safely passing lon, lat, and radius into SQL
     rows = cur.fetchall()  # getting all matching nearby buildings
 
     cur.close()  
@@ -644,6 +667,103 @@ def format_location_comparison(first_label, first_buildings, second_label, secon
     return "\n".join(lines)
 
 
+def normalize_street_query_parts(address_text):
+    parts = [part.strip() for part in address_text.split(",") if part.strip()]
+    if not parts:
+        return []
+
+    normalized_parts = []
+    for index, part in enumerate(parts):
+        lower_part = part.lower()
+        if lower_part in {"united states", "usa", "us"}:
+            continue
+        if index == 0:
+            normalized_parts.append(part)
+            continue
+        zip_match = re.search(r"\b\d{5}\b", part)
+        if zip_match:
+            normalized_parts.append(zip_match.group(0))
+        elif lower_part == "texas":
+            normalized_parts.append("Texas")
+        elif lower_part == "tx":
+            normalized_parts.append("TX")
+        else:
+            normalized_parts.append(part)
+
+    return normalized_parts
+
+
+def get_buildings_on_address_text(address_text, damage_filter=None):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    address_parts = normalize_street_query_parts(address_text)
+    if not address_parts:
+        return []
+
+    street_part = address_parts[0]
+    street_core = re.sub(
+        r"\b(street|st|avenue|ave|road|rd|drive|dr|lane|ln|boulevard|blvd|court|ct|place|pl|way)\b",
+        "",
+        street_part,
+        flags=re.IGNORECASE,
+    ).strip()
+    city_part = address_parts[1] if len(address_parts) > 1 else None
+    state_or_zip_parts = address_parts[2:]
+
+    base_query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE b.address IS NOT NULL
+    """
+
+    strict_query = base_query
+    strict_params = []
+    for part in address_parts:
+        strict_query += " AND b.address ILIKE %s"
+        strict_params.append(f"%{part}%")
+    if damage_filter:
+        strict_query += " AND b.predicted_damage = %s"
+        strict_params.append(damage_filter)
+
+    cur.execute(strict_query, tuple(strict_params))
+    rows = cur.fetchall()
+
+    if len(rows) == 0:
+        relaxed_query = base_query
+        relaxed_params = []
+
+        if street_core:
+            relaxed_query += " AND b.address ILIKE %s"
+            relaxed_params.append(f"%{street_core}%")
+        else:
+            relaxed_query += " AND b.address ILIKE %s"
+            relaxed_params.append(f"%{street_part}%")
+
+        if city_part:
+            relaxed_query += " AND b.address ILIKE %s"
+            relaxed_params.append(f"%{city_part}%")
+
+        for part in state_or_zip_parts:
+            if re.fullmatch(r"\d{5}", part):
+                continue
+            relaxed_query += " AND b.address ILIKE %s"
+            relaxed_params.append(f"%{part}%")
+
+        if damage_filter:
+            relaxed_query += " AND b.predicted_damage = %s"
+            relaxed_params.append(damage_filter)
+
+        cur.execute(relaxed_query, tuple(relaxed_params))
+        rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
 def get_buildings_by_address_text(address_text, damage_filter):
     conn = get_db_connection()
     cur = conn.cursor()
@@ -761,6 +881,39 @@ def get_primary_xbd_id(buildings):
         return None
 
     return random.choice(xbd_ids)
+
+
+def get_dominant_xbd_id(buildings):
+    counts: dict[int, int] = {}
+
+    for building in buildings:
+        xbd_id = building.get("xbd_id")
+        if xbd_id is None:
+            continue
+        counts[xbd_id] = counts.get(xbd_id, 0) + 1
+
+    if not counts:
+        return None
+
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def get_nearest_xbd_id(buildings):
+    for building in buildings:
+        xbd_id = building.get("xbd_id")
+        if xbd_id is not None:
+            return xbd_id
+    return None
+
+
+def is_all_buildings_query(question):
+    q = question.lower()
+    return any(phrase in q for phrase in [
+        "all buildings",
+        "all properties",
+        "all records",
+        "all damage levels",
+    ])
 
 
 def get_buildings_for_primary_scene(buildings, primary_xbd_id=None):
@@ -918,7 +1071,7 @@ def build_map_action(geo, buildings):
         if b.get("xbd_id") is not None  # ignore missing xbd_id values
     })
 
-    primary_xbd_id = xbd_ids[0] if len(xbd_ids) == 1 else None  # only choose route if all buildings are from one xbd scene
+    primary_xbd_id = xbd_ids[0] if len(xbd_ids) == 1 else get_dominant_xbd_id(buildings)
 
     return {
         "type": "navigate",  # tells frontend this action should navigate somewhere
@@ -1190,8 +1343,7 @@ def is_data_summary_query(question):
 
 def is_full_dataset_query(question):
     q = question.lower()
-
-    return any(k in q for k in [
+    has_dataset_phrase = any(k in q for k in [
         "full dataset",
         "whole dataset",
         "entire dataset",
@@ -1200,6 +1352,11 @@ def is_full_dataset_query(question):
         "dataset summary",
         "overall damage in the dataset"
     ])
+    if not has_dataset_phrase:
+        return False
+
+    scoped_location_phrases = [" near ", " in ", " on ", " around ", " at "]
+    return not any(phrase in q for phrase in scoped_location_phrases)
 
 
 def is_conversation_summary_query(question):
@@ -1581,11 +1738,63 @@ def handle_chat_query(question):
         }
 
     _, damage_type = parse_question(question)
+    wants_all_buildings = is_all_buildings_query(question)
+
+    on_location_text = extract_on_location_text(question)
+    if on_location_text and "near" not in question.lower():
+        requested_damage = None if wants_all_buildings else damage_type
+        buildings = get_buildings_on_address_text(on_location_text, requested_damage)
+        primary_xbd_id = get_dominant_xbd_id(buildings)
+        scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
+        geo = geocode_address(on_location_text)
+
+        if len(buildings) == 0:
+            answer = f"I could not find relevant damage data for addresses on {on_location_text}."
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": {
+                    "lat": geo["lat"],
+                    "lon": geo["lon"],
+                    "address": geo["formatted_address"]
+                } if geo else None,
+                "highlighted_buildings": [],
+                "action": build_no_action()
+            }
+
+        label_text = geo["formatted_address"] if geo else on_location_text
+        if wants_all_buildings:
+            counts = count_damage_levels(buildings)
+            answer = format_damage_bullet_summary(counts, f"addresses on {label_text}")
+        elif damage_type == "no-damage":
+            answer = f"{len(buildings)} buildings on {label_text} appear to have no visible damage."
+        else:
+            answer = generate_llm_answer(buildings, label_text, damage_type)
+
+        action = (
+            build_building_action(buildings[0])
+            if len(buildings) == 1
+            else build_map_action_from_buildings(buildings, label_text, primary_xbd_id)
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": {
+                "lat": geo["lat"],
+                "lon": geo["lon"],
+                "address": geo["formatted_address"]
+            } if geo else None,
+            "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
+            "action": action
+        }
 
     address_filter_text = extract_address_filter_text(question)
     if address_filter_text:
         buildings = get_buildings_by_address_text(address_filter_text, damage_type)
-        primary_xbd_id = get_primary_xbd_id(buildings)
+        primary_xbd_id = get_dominant_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
         geo = geocode_address(address_filter_text)
 
@@ -1640,7 +1849,7 @@ def handle_chat_query(question):
             )
         if len(buildings) == 0:
             buildings = get_buildings_by_address_text(in_location_text, damage_type)
-        primary_xbd_id = get_primary_xbd_id(buildings)
+        primary_xbd_id = get_dominant_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
 
         if len(buildings) == 0:
@@ -1685,8 +1894,8 @@ def handle_chat_query(question):
             b for b in all_buildings
             if b.get("damage") == damage_type
         ]
-        primary_all_xbd_id = get_primary_xbd_id(all_buildings)
-        primary_filtered_xbd_id = get_primary_xbd_id(filtered_buildings)
+        primary_all_xbd_id = get_dominant_xbd_id(all_buildings)
+        primary_filtered_xbd_id = get_dominant_xbd_id(filtered_buildings)
         scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
         scene_filtered_buildings = get_buildings_for_primary_scene(filtered_buildings, primary_filtered_xbd_id)
 
@@ -1770,12 +1979,8 @@ def handle_chat_query(question):
         used_address_fallback = len(all_buildings) == 0
         if used_address_fallback:
             all_buildings = get_all_buildings_by_address_text(address)
-        primary_all_xbd_id = get_primary_xbd_id(all_buildings)
-        scene_all_buildings = (
-            get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
-            if used_address_fallback
-            else all_buildings
-        )
+        primary_all_xbd_id = get_nearest_xbd_id(all_buildings)
+        scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
 
         counts = count_damage_levels(all_buildings)
 
@@ -1785,11 +1990,7 @@ def handle_chat_query(question):
         )
 
         # create a map navigation action so frontend can route/focus to the result area
-        action = (
-            build_map_action_from_buildings(all_buildings, geo["formatted_address"], primary_all_xbd_id)
-            if used_address_fallback
-            else build_map_action(geo, all_buildings)
-        )
+        action = build_map_action_from_buildings(all_buildings, geo["formatted_address"], primary_all_xbd_id)
 
         # package chatbot answer, map focus, highlighted buildings, and navigation action
         payload = build_map_payload(answer, geo, scene_all_buildings, action)
@@ -1809,12 +2010,8 @@ def handle_chat_query(question):
         used_address_fallback = len(all_buildings) == 0
         if used_address_fallback:
             all_buildings = get_all_buildings_by_address_text(address)
-        primary_all_xbd_id = get_primary_xbd_id(all_buildings)
-        scene_all_buildings = (
-            get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
-            if used_address_fallback
-            else all_buildings
-        )
+        primary_all_xbd_id = get_nearest_xbd_id(all_buildings)
+        scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
 
         if len(all_buildings) == 0:
             answer = "I couldn't find enough nearby damage data to give a reliable advisory for that area."
@@ -1823,11 +2020,7 @@ def handle_chat_query(question):
             answer = advisory_response(question, all_buildings, geo["formatted_address"])
 
             # create a map navigation action because advisory answers still relate to this location
-            action = (
-                build_map_action_from_buildings(all_buildings, geo["formatted_address"], primary_all_xbd_id)
-                if used_address_fallback
-                else build_map_action(geo, all_buildings)
-            )
+            action = build_map_action_from_buildings(all_buildings, geo["formatted_address"], primary_all_xbd_id)
 
         # package chatbot answer, map focus, highlighted buildings, and navigation action
         payload = build_map_payload(answer, geo, scene_all_buildings, action)
@@ -1843,15 +2036,23 @@ def handle_chat_query(question):
         5000,
         damage_type
     )
+    all_nearby_buildings = get_all_buildings_near(
+        geo["lon"],
+        geo["lat"],
+        5000
+    )
     used_address_fallback = len(buildings) == 0
     if used_address_fallback:
         buildings = get_buildings_by_address_text(address, damage_type)
-    primary_buildings_xbd_id = get_primary_xbd_id(buildings)
-    scene_buildings = (
-        get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
-        if used_address_fallback
-        else buildings
+    primary_buildings_xbd_id = (
+        get_nearest_xbd_id(all_nearby_buildings)
+        if len(all_nearby_buildings) > 0
+        else get_nearest_xbd_id(buildings)
     )
+    scene_buildings = get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
+    if len(scene_buildings) == 0:
+        primary_buildings_xbd_id = get_nearest_xbd_id(buildings)
+        scene_buildings = get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
 
     if len(buildings) == 0:
         answer = "I could not find relevant damage data for that area. Try a different location."
@@ -1879,11 +2080,7 @@ def handle_chat_query(question):
 
     # if multiple buildings matched, frontend should route/focus to the map view
     else:
-        action = (
-            build_map_action_from_buildings(buildings, geo["formatted_address"], primary_buildings_xbd_id)
-            if used_address_fallback
-            else build_map_action(geo, buildings)
-        )
+        action = build_map_action_from_buildings(buildings, geo["formatted_address"], primary_buildings_xbd_id)
 
     # package chatbot answer, map focus, highlighted buildings, and navigation action
     payload = build_map_payload(answer, geo, scene_buildings, action)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -32,6 +32,8 @@ load_dotenv(BACKEND_DIR / ".env", override=True)
 # frontend route example: /map/hurricane-harvey/3?building=<building_uid>
 # this can be changed later through backend/.env if needed
 DEFAULT_DISASTER_NAME = os.getenv("DEFAULT_DISASTER_NAME", "hurricane-harvey")
+STREET_ADDRESS_OVERVIEW_RADIUS_M = 300
+EXACT_ADDRESS_OVERVIEW_RADIUS_M = 75
 
 
 # function to connect to database using environment variables
@@ -208,6 +210,48 @@ def extract_general_location_text(question):
 
 
 # function to convert address → latitude/longitude using Mapbox API
+def looks_like_street_address(location_text):
+    normalized = location_text.strip().lower()
+    street_markers = [
+        "street",
+        "st",
+        "avenue",
+        "ave",
+        "road",
+        "rd",
+        "drive",
+        "dr",
+        "boulevard",
+        "blvd",
+        "lane",
+        "ln",
+        "way",
+        "court",
+        "ct",
+        "place",
+        "pl",
+        "circle",
+        "cir",
+        "parkway",
+        "pkwy",
+        "highway",
+        "hwy",
+    ]
+    has_house_number = bool(re.search(r"\b\d+\b", normalized))
+    has_street_marker = any(
+        re.search(rf"\b{re.escape(marker)}\b", normalized)
+        for marker in street_markers
+    )
+    return has_house_number or has_street_marker
+
+
+def looks_like_exact_address(location_text):
+    normalized = location_text.strip().lower()
+    return looks_like_street_address(normalized) and bool(
+        re.search(r"\b\d+\b", normalized)
+    )
+
+
 def geocode_address(address):
 
     api_key = os.getenv("MAPBOX_API_KEY")  # getting API key
@@ -480,10 +524,27 @@ def resolve_location_buildings(location_text):
         if DEFAULT_DISASTER_NAME == "hurricane-harvey":
             geocode_query = f"{normalized_location}, Texas"
 
+    if looks_like_exact_address(normalized_location):
+        buildings = get_buildings_on_address_text(normalized_location, None)
+        if len(buildings) > 0:
+            return None, normalized_location, buildings
+
     geo = geocode_address(geocode_query)
     buildings = []
 
-    if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
+    if geo and looks_like_exact_address(normalized_location):
+        buildings = get_all_buildings_near(
+            geo["lon"],
+            geo["lat"],
+            EXACT_ADDRESS_OVERVIEW_RADIUS_M,
+        )
+    elif geo and looks_like_street_address(normalized_location):
+        buildings = get_all_buildings_near(
+            geo["lon"],
+            geo["lat"],
+            STREET_ADDRESS_OVERVIEW_RADIUS_M,
+        )
+    elif geo and geo.get("bbox") and len(geo["bbox"]) == 4:
         min_lon, min_lat, max_lon, max_lat = geo["bbox"]
         buildings = get_all_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat)
 
@@ -838,6 +899,33 @@ def get_buildings_on_address_text(address_text, damage_filter=None):
     return rows_to_buildings(rows)
 
 
+def get_buildings_for_xbd(xbd_id, damage_filter=None):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    JOIN disasters d ON ip.disaster_id = d.id
+    WHERE d.name = %s
+      AND ip.xbd_id = %s
+    """
+    params = [DEFAULT_DISASTER_NAME, xbd_id]
+
+    if damage_filter:
+        query += " AND b.predicted_damage = %s"
+        params.append(damage_filter)
+
+    cur.execute(query, tuple(params))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
 def get_buildings_by_address_text(address_text, damage_filter):
     conn = get_db_connection()
     cur = conn.cursor()
@@ -944,6 +1032,21 @@ def build_map_action_from_buildings(buildings, address_text=None, primary_xbd_id
     }
 
 
+def build_scene_action(xbd_id, building_ids=None, label_text=None):
+    return {
+        "type": "navigate",
+        "target": "map",
+        "reason": "scene_query",
+        "url": build_map_route(DEFAULT_DISASTER_NAME, xbd_id),
+        "params": {
+            "disaster_name": DEFAULT_DISASTER_NAME,
+            "xbd_id": xbd_id,
+            "address": label_text,
+            "building_ids": building_ids or [],
+        },
+    }
+
+
 def get_primary_xbd_id(buildings):
     xbd_ids = sorted({
         building.get("xbd_id")
@@ -978,6 +1081,17 @@ def get_nearest_xbd_id(buildings):
         if xbd_id is not None:
             return xbd_id
     return None
+
+
+def extract_xbd_query_id(question):
+    match = re.search(r"\bxbd\s*#?\s*(\d+)\b", question, flags=re.IGNORECASE)
+    if not match:
+        return None
+
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
 
 
 def is_all_buildings_query(question):
@@ -1861,14 +1975,61 @@ def handle_chat_query(question):
 
     _, damage_type = parse_question(question)
     wants_all_buildings = is_all_buildings_query(question)
+    xbd_query_id = extract_xbd_query_id(question)
+
+    if xbd_query_id is not None:
+        requested_damage = None if wants_all_buildings else damage_type
+        buildings = get_buildings_for_xbd(xbd_query_id, requested_damage)
+
+        if len(buildings) == 0:
+            answer = (
+                f"I could not find relevant damage data for XBD {xbd_query_id}."
+            )
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
+
+        label_text = f"XBD {xbd_query_id}"
+        if wants_all_buildings:
+            counts = count_damage_levels(buildings)
+            answer = synthesize_location_overview_answer(label_text, counts)
+        elif damage_type == "no-damage":
+            answer = f"{len(buildings)} buildings on {label_text} appear to have no visible damage."
+        else:
+            answer = generate_llm_answer(buildings, label_text, damage_type)
+
+        action = (
+            build_building_action(buildings[0])
+            if len(buildings) == 1
+            else build_scene_action(
+                xbd_query_id,
+                [building["uid"] for building in buildings],
+                label_text,
+            )
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": buildings,
+            "action": action,
+        }
 
     on_location_text = extract_on_location_text(question)
     if on_location_text and "near" not in question.lower():
+        has_explicit_region = "," in on_location_text
         requested_damage = None if wants_all_buildings else damage_type
         buildings = get_buildings_on_address_text(on_location_text, requested_damage)
         primary_xbd_id = get_dominant_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
-        geo = geocode_address(on_location_text)
+        geo = geocode_address(on_location_text) if has_explicit_region else None
 
         if len(buildings) == 0:
             answer = f"I could not find relevant damage data for addresses on {on_location_text}."
@@ -1885,7 +2046,7 @@ def handle_chat_query(question):
                 "action": build_no_action()
             }
 
-        label_text = geo["formatted_address"] if geo else on_location_text
+        label_text = geo["formatted_address"] if geo and has_explicit_region else on_location_text
         if wants_all_buildings:
             counts = count_damage_levels(buildings)
             answer = synthesize_location_overview_answer(f"addresses on {label_text}", counts)
@@ -1904,11 +2065,7 @@ def handle_chat_query(question):
         return {
             "answer": answer,
             "response": answer,
-            "focus": {
-                "lat": geo["lat"],
-                "lon": geo["lon"],
-                "address": geo["formatted_address"]
-            } if geo else None,
+            "focus": None,
             "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
             "action": action
         }

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -483,22 +483,33 @@ def fetch_city_damage_stats(limit=20):
     cur = conn.cursor()
 
     query = """
+    WITH building_cities AS (
+      SELECT
+        CASE
+          WHEN TRIM(SPLIT_PART(b.address, ',', 2)) ~* '[0-9]'
+            OR LOWER(TRIM(SPLIT_PART(b.address, ',', 2))) IN ('texas', 'tx')
+          THEN TRIM(SPLIT_PART(b.address, ',', 1))
+          ELSE TRIM(SPLIT_PART(b.address, ',', 2))
+        END AS city,
+        b.predicted_damage
+      FROM buildings b
+      JOIN image_pairs ip ON b.image_pair_id = ip.id
+      JOIN disasters d ON ip.disaster_id = d.id
+      WHERE b.address IS NOT NULL
+        AND d.name = %s
+        AND POSITION(',' IN b.address) > 0
+    )
     SELECT
-      TRIM(SPLIT_PART(b.address, ',', 2)) AS city,
+      city,
       COUNT(*) AS total,
-      SUM(CASE WHEN b.predicted_damage = 'no-damage' THEN 1 ELSE 0 END) AS no_damage,
-      SUM(CASE WHEN b.predicted_damage = 'minor-damage' THEN 1 ELSE 0 END) AS minor_damage,
-      SUM(CASE WHEN b.predicted_damage = 'major-damage' THEN 1 ELSE 0 END) AS major_damage,
-      SUM(CASE WHEN b.predicted_damage = 'destroyed' THEN 1 ELSE 0 END) AS destroyed
-    FROM buildings b
-    JOIN image_pairs ip ON b.image_pair_id = ip.id
-    JOIN disasters d ON ip.disaster_id = d.id
-    WHERE b.address IS NOT NULL
-      AND d.name = %s
-      AND POSITION(',' IN b.address) > 0
-      AND POSITION(',' IN SUBSTRING(b.address FROM POSITION(',' IN b.address) + 1)) > 0
-    GROUP BY TRIM(SPLIT_PART(b.address, ',', 2))
-    HAVING TRIM(SPLIT_PART(b.address, ',', 2)) <> ''
+      SUM(CASE WHEN predicted_damage = 'no-damage' THEN 1 ELSE 0 END) AS no_damage,
+      SUM(CASE WHEN predicted_damage = 'minor-damage' THEN 1 ELSE 0 END) AS minor_damage,
+      SUM(CASE WHEN predicted_damage = 'major-damage' THEN 1 ELSE 0 END) AS major_damage,
+      SUM(CASE WHEN predicted_damage = 'destroyed' THEN 1 ELSE 0 END) AS destroyed
+    FROM building_cities
+    WHERE city <> ''
+      AND city !~* '^[0-9]+$'
+    GROUP BY city
     ORDER BY total DESC, city ASC
     LIMIT %s
     """
@@ -510,6 +521,23 @@ def fetch_city_damage_stats(limit=20):
     conn.close()
 
     return rows
+
+
+def format_city_list_response(rows):
+    if len(rows) == 0:
+        return "I couldn't find any city-level data for the active disaster dataset."
+
+    city_names = []
+    seen = set()
+    for row in rows:
+        city = str(row[0]).strip()
+        if not city or city.lower() in seen:
+            continue
+        seen.add(city.lower())
+        city_names.append(city)
+
+    sample = city_names[:12]
+    return "Cities in the dataset are: " + ", ".join(sample) + "."
 
 
 def resolve_location_buildings(location_text):
@@ -1730,7 +1758,7 @@ def format_city_damage_stats(rows):
 
 
 def synthesize_city_damage_stats_answer(rows):
-    fallback = format_city_damage_stats(rows)
+    fallback = format_city_list_response(rows)
     prompt = f"""
 You are Hazardly, a disaster damage assessment assistant.
 
@@ -1740,9 +1768,9 @@ City rows: {rows[:8]}
 Write a concise answer for the user.
 
 Rules:
-- Use 3 to 5 short bullet points.
-- Keep city names and counts exact.
-- Mention that this is a sample of cities in the active dataset.
+- Return a plain list of city names only.
+- Do not include damage counts or rankings.
+- Use a natural city-list intro sentence.
 - Do not invent extra places or numbers.
 """
     return synthesize_structured_answer(prompt, fallback)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -119,6 +119,8 @@ CITY_METRIC_LABEL = {
     "minor-damage": "minorly damaged buildings",
     "major-damage": "majorly damaged buildings",
     "destroyed": "destroyed buildings",
+    "severe-damage": "severely damaged buildings",
+    "least-severe-damage": "severely damaged buildings",
 }
 DAMAGE_LABEL_TEXT = {
     "no-damage": "undamaged",
@@ -974,8 +976,12 @@ def extract_top_n(question, default=5):
 
 def get_ranking_metric(question):
     q = question.lower()
+    if any(term in q for term in ["least damaged", "least damage"]):
+        return "least-severe-damage"
     if any(term in q for term in ["destroyed", "hardest-hit", "hardest hit", "hit hardest"]):
         return "destroyed"
+    if any(term in q for term in ["most damaged", "most damage", "worst damage", "worst damaged"]):
+        return "severe-damage"
     if "major" in q:
         return "major-damage"
     if "minor" in q:
@@ -987,7 +993,6 @@ def get_ranking_metric(question):
         "non-damaged",
         "non damaged",
         "not damaged",
-        "least damage",
     ]):
         return "no-damage"
     return "total"
@@ -1033,7 +1038,33 @@ def format_scene_count_response(total_scenes):
 
 
 def format_scene_label(scene_id):
-    return f"scene {scene_id}"
+    return f"Scene {scene_id}"
+
+
+def format_damage_class_label(damage_type):
+    labels = {
+        "no-damage": "no visible damage",
+        "minor-damage": "minor-damage",
+        "major-damage": "major-damage",
+        "destroyed": "destroyed",
+    }
+    return labels.get(damage_type, str(damage_type).replace("-", " "))
+
+
+def format_scene_damage_answer(scene_label, building_count, damage_type):
+    building_label = "building" if building_count == 1 else "buildings"
+    damage_label = format_damage_class_label(damage_type)
+
+    if damage_type == "no-damage":
+        return (
+            f"{scene_label} contains {building_count} {building_label} classified as "
+            "no visible damage in the active dataset."
+        )
+
+    return (
+        f"{scene_label} contains {building_count} {building_label} classified as "
+        f"{damage_label} in the active dataset."
+    )
 
 
 def format_scene_ranking(rows, metric, limit):
@@ -1078,6 +1109,11 @@ def get_top_scene_for_metric(rows, metric):
 
 
 def sort_city_rows(rows, metric):
+    if metric == "severe-damage":
+        return sorted(rows, key=lambda row: (-(row[4] + row[5]), -row[1], row[0]))
+    if metric == "least-severe-damage":
+        return sorted(rows, key=lambda row: (row[4] + row[5], -row[1], row[0]))
+
     metric_index = CITY_METRIC_INDEX[metric]
     return sorted(rows, key=lambda row: (-row[metric_index], row[0]))
 
@@ -1088,19 +1124,34 @@ def format_city_ranking(rows, metric, limit):
 
     sorted_rows = sort_city_rows(rows, metric)
     limited_rows = sorted_rows[:limit]
-    metric_index = CITY_METRIC_INDEX[metric]
+    metric_index = (
+        None
+        if metric in {"severe-damage", "least-severe-damage"}
+        else CITY_METRIC_INDEX[metric]
+    )
     metric_label = CITY_METRIC_LABEL[metric]
 
-    header = (
-        f"Cities in the dataset by {metric_label}:"
-        if limit >= len(sorted_rows)
-        else f"Top cities by {metric_label}:"
-    )
+    if metric == "least-severe-damage":
+        header = (
+            "Cities in the dataset with the fewest severely damaged buildings:"
+            if limit >= len(sorted_rows)
+            else "Cities with the fewest severely damaged buildings:"
+        )
+    else:
+        header = (
+            f"Cities in the dataset by {metric_label}:"
+            if limit >= len(sorted_rows)
+            else f"Top cities by {metric_label}:"
+        )
 
     lines = [header]
     for row in limited_rows:
         city = row[0]
-        value = row[metric_index]
+        value = (
+            row[4] + row[5]
+            if metric in {"severe-damage", "least-severe-damage"}
+            else row[metric_index]
+        )
         total = row[1]
         lines.append(f"- {city}: {value} {metric_label}, {total} total")
 
@@ -1330,6 +1381,28 @@ def get_buildings_for_xbd(xbd_id, damage_filter=None):
     conn.close()
 
     return rows_to_buildings(rows)
+
+
+def scene_exists(xbd_id):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT 1
+    FROM image_pairs ip
+    JOIN disasters d ON ip.disaster_id = d.id
+    WHERE d.name = %s
+      AND ip.xbd_id = %s
+    LIMIT 1
+    """
+
+    cur.execute(query, (DEFAULT_DISASTER_NAME, xbd_id))
+    exists = cur.fetchone() is not None
+
+    cur.close()
+    conn.close()
+
+    return exists
 
 
 def get_misclassified_buildings_for_xbd(xbd_id):
@@ -2036,6 +2109,13 @@ def is_full_dataset_query(question):
         "overall dataset",
         "dataset summary",
         "overall damage in the dataset",
+        "what is the data",
+        "what is this data",
+        "what is the dataset",
+        "what is this dataset",
+        "what data is this",
+        "what dataset is this",
+        "what does the data show",
         "tell me about the data",
         "tell me about the dataset",
         "about the data",
@@ -2101,6 +2181,32 @@ def is_damage_label_query(question):
         "what damage levels exist",
         "what labels are in the dataset",
     ])
+
+
+def is_active_disaster_query(question):
+    normalized_question = re.sub(r"\s+", " ", question.strip().lower()).strip(" ?.")
+    return normalized_question in {
+        "what disaster is this",
+        "what disaster is this dataset",
+        "what disaster is this data",
+        "what disaster are we looking at",
+        "what disaster am i looking at",
+        "which disaster is this",
+        "which disaster are we looking at",
+        "what is the active disaster",
+        "what disaster is active",
+    }
+
+
+def format_disaster_name(disaster_name):
+    return str(disaster_name).replace("-", " ").title()
+
+
+def active_disaster_response():
+    return (
+        f"The active disaster dataset is {format_disaster_name(DEFAULT_DISASTER_NAME)}. "
+        "You can ask for a dataset summary, affected cities, xBD scenes, or building damage near a location."
+    )
 
 
 def is_help_query(question):
@@ -2178,11 +2284,31 @@ def acknowledgement_response():
 
 
 def help_response():
-    return "\n".join([
-        "I can help with disaster damage assessment questions for the active dataset.",
-        "Try asking for a dataset summary, affected cities, damage counts, damaged buildings near a city or address, a specific xBD scene, misclassified buildings, or safety/repair guidance based on nearby damage levels.",
-        "Examples: \"Show destroyed buildings near Houston\", \"Summarize damage in Sugar Land\", or \"What cities have the most major damage?\"",
-    ])
+    options = [
+        "\n".join([
+            "I can help with disaster damage assessment questions for the active dataset.",
+            "Try asking for a dataset summary, affected cities, damage counts, damaged buildings near a city or address, a specific xBD scene, misclassified buildings, or safety/repair guidance based on nearby damage levels.",
+            "Examples: \"Show major damage near Houston\", \"Summarize damage in Sugar Land\", or \"What cities have the most major damage?\"",
+        ]),
+        "\n".join([
+            "I can help you explore damage patterns in the active disaster dataset.",
+            "You can ask about affected cities, scene-level damage, building counts by severity, misclassified buildings, or conditions near a city, area, address, or xBD scene.",
+            "Examples: \"What happened to Richmond?\", \"Show scene 18\", or \"Which cities have the most destroyed buildings?\"",
+        ]),
+        "\n".join([
+            "I am best at answering questions about disaster damage assessment data.",
+            "Ask me to summarize the dataset, compare locations, list affected cities, find damaged buildings, explain damage labels, or give safety and repair guidance based on nearby damage.",
+            "Examples: \"Summarize the full dataset\", \"Compare Missouri City and Cypress\", or \"What damage labels exist?\"",
+        ]),
+    ]
+
+    previous_help_response_count = sum(
+        1
+        for message in get_chat_history()
+        if message.get("role") == "assistant"
+        and message.get("content") in options
+    )
+    return options[previous_help_response_count % len(options)]
 
 
 def ambiguous_query_response(parsed_query):
@@ -2249,6 +2375,9 @@ def classify_query_intent_heuristic(question):
 
     if is_acknowledgement_query(question):
         return "acknowledgement"
+
+    if is_active_disaster_query(question):
+        return "active_disaster"
 
     if is_help_query(question):
         return "help"
@@ -2341,6 +2470,7 @@ Choose exactly one label from this list:
 - greeting
 - identity
 - acknowledgement
+- active_disaster
 - help
 - location_comparison
 - location_percentage
@@ -2364,6 +2494,7 @@ Definitions:
 - greeting: brief conversational opener such as hello, hi, or hey
 - identity: asks who the assistant is or what it does
 - acknowledgement: brief thanks or acknowledgement after the assistant has answered
+- active_disaster: asks which active disaster or disaster dataset is being viewed
 - help: asks what the assistant can do or what questions are supported
 - location_comparison: compares two named locations
 - location_percentage: asks what percentage/share of buildings in a place fit a damage level
@@ -2387,6 +2518,9 @@ Label: city_list
 
 Question: What can you help with?
 Label: help
+
+Question: What disaster is this?
+Label: active_disaster
 
 Question: Compare Houston and Sugar Land
 Label: location_comparison
@@ -2433,6 +2567,7 @@ Label:
         "greeting",
         "identity",
         "acknowledgement",
+        "active_disaster",
         "help",
         "location_comparison",
         "location_percentage",
@@ -2557,6 +2692,7 @@ def parse_structured_query(question):
         "greeting": "greeting",
         "identity": "identity",
         "acknowledgement": "acknowledgement",
+        "active_disaster": "active_disaster",
         "help": "help",
         "location_comparison": "location_comparison",
         "location_percentage": "location_percentage",
@@ -2689,6 +2825,7 @@ def parse_structured_query(question):
         "greeting",
         "identity",
         "acknowledgement",
+        "active_disaster",
         "help",
         "conversation_summary",
         "scene_count",
@@ -2706,6 +2843,7 @@ def parse_structured_query(question):
         "locations": locations,
         "comparison": mapped_intent == "location_comparison",
         "damage_filter": damage_filter,
+        "has_explicit_damage_filter": has_explicit_damage_filter,
         "needs_map": wants_navigation or mapped_intent == "location_query",
         "scope": infer_scope(primary_location, explicit_scene_id),
         "entity_type": entity_type,
@@ -2886,6 +3024,17 @@ def handle_chat_query(question, session_id=None):
 
     if intent == "acknowledgement":
         answer = acknowledgement_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()
+        }
+
+    if intent == "active_disaster":
+        answer = active_disaster_response()
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -3180,7 +3329,8 @@ def handle_chat_query(question, session_id=None):
     # full dataset summary does not have a single map focus
     if intent == "dataset_overview":
         counts = get_full_dataset_damage_counts()
-        damage_key = damage_type if isinstance(damage_type, str) else None
+        parsed_damage_filter = parsed_query["damage_filter"]
+        damage_key = parsed_damage_filter if isinstance(parsed_damage_filter, str) else None
         damage_label = get_damage_label_text(damage_key)
         if damage_key and damage_label and damage_key in counts:
             answer = "\n".join([
@@ -3212,13 +3362,21 @@ def handle_chat_query(question, session_id=None):
         }
 
     if intent == "scene_query" and xbd_query_id is not None:
-        requested_damage = None if wants_all_buildings else damage_type
+        requested_damage = (
+            damage_type
+            if parsed_query["has_explicit_damage_filter"] and not wants_all_buildings
+            else None
+        )
         buildings = get_buildings_for_xbd(xbd_query_id, requested_damage)
 
         if len(buildings) == 0:
-            answer = (
-                f"I could not find relevant damage data for {format_scene_label(xbd_query_id)}."
-            )
+            if not scene_exists(xbd_query_id):
+                answer = f"{format_scene_label(xbd_query_id)} does not exist in the active dataset."
+            else:
+                answer = (
+                    f"{format_scene_label(xbd_query_id)} exists, but I could not find matching "
+                    "building damage data for that request."
+                )
             save_turn(question, answer)
             return {
                 "answer": answer,
@@ -3229,13 +3387,11 @@ def handle_chat_query(question, session_id=None):
             }
 
         label_text = format_scene_label(xbd_query_id)
-        if wants_all_buildings:
+        if requested_damage is None:
             counts = count_damage_levels(buildings)
             answer = synthesize_location_overview_answer(label_text, counts)
-        elif damage_type == "no-damage":
-            answer = f"{len(buildings)} buildings on {label_text} appear to have no visible damage."
         else:
-            answer = generate_llm_answer(buildings, label_text, damage_type)
+            answer = format_scene_damage_answer(label_text, len(buildings), damage_type)
 
         action = (
             build_building_action(buildings[0])

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -151,6 +151,39 @@ NEARBY_SEARCH_RADIUS_METERS = 5000
 # Canonical damage labels matching the database `damage_level` enum.
 DAMAGE_LEVELS = ("no-damage", "minor-damage", "major-damage", "destroyed")
 
+DISASTER_GUIDANCE_TOPICS = {
+    "flood": {
+        "title": "flood",
+        "source": "Ready.gov Floods",
+        "url": "https://www.ready.gov/floods",
+        "path": BACKEND_DIR / "resources" / "disaster_guidance" / "ready_gov_floods.md",
+        "aliases": (
+            "flood",
+            "flooding",
+            "flash flood",
+            "floodwater",
+            "floodwaters",
+        ),
+    },
+    "hurricane": {
+        "title": "hurricane",
+        "source": "Ready.gov Hurricanes",
+        "url": "https://www.ready.gov/hurricanes",
+        "path": BACKEND_DIR / "resources" / "disaster_guidance" / "ready_gov_hurricanes.md",
+        "aliases": (
+            "hurricane",
+            "hurricanes",
+            "typhoon",
+            "typhoons",
+            "tropical storm",
+            "storm surge",
+        ),
+    },
+}
+DISASTER_GUIDANCE_SAFETY_MESSAGE = (
+    "Follow local emergency officials for current instructions, and call 911 for immediate emergencies."
+)
+
 
 def format_radius_label(radius_m):
     if radius_m >= 1000:
@@ -492,6 +525,310 @@ def detect_advisory(question):
 
     #if none then it is not an advisory 
     return None
+
+
+def detect_disaster_guidance_topics(question):
+    q = question.lower()
+    topics = []
+    for topic, metadata in DISASTER_GUIDANCE_TOPICS.items():
+        if any(alias in q for alias in metadata["aliases"]):
+            topics.append(topic)
+    return topics
+
+
+def detect_disaster_guidance_topic(question):
+    topics = detect_disaster_guidance_topics(question)
+    return topics[0] if topics else None
+
+
+def detect_disaster_guidance_section(question):
+    q = question.lower()
+
+    if any(term in q for term in ["insurance", "claim", "coverage", "nfip"]):
+        return "insurance"
+    if any(term in q for term in ["resource", "resources", "link", "learn more", "where can i"]):
+        return "resources"
+    if any(term in q for term in ["alert", "alerts", "warning system", "fema app", "weather radio"]):
+        return "alerts"
+    if any(term in q for term in ["before", "prepare", "prepared", "preparation", "plan", "supplies", "kit"]):
+        return "before"
+    if any(term in q for term in ["warning", "during", "evacuate", "evacuation", "shelter", "trapped"]):
+        return "during"
+    if any(term in q for term in ["after", "cleanup", "clean up", "return home", "recovery", "recover"]):
+        return "after"
+    return "overview"
+
+
+def is_general_disaster_guidance_request(question):
+    q = question.lower()
+    guidance_phrases = [
+        "disaster guidance",
+        "disaster safety",
+        "general disaster",
+        "emergency preparedness",
+        "emergency plan",
+        "ready.gov",
+        "ready gov",
+        "fema guidance",
+        "fema safety",
+        "what should i do in a disaster",
+        "what do i do in a disaster",
+    ]
+    return any(phrase in q for phrase in guidance_phrases)
+
+
+def is_disaster_guidance_query(question):
+    q = question.lower()
+    topic = detect_disaster_guidance_topic(question)
+
+    if is_general_disaster_guidance_request(question):
+        return True
+
+    if not topic:
+        return False
+
+    guidance_terms = [
+        "what is",
+        "what are",
+        "tell me about",
+        "explain",
+        "guidance",
+        "fact",
+        "facts",
+        "info",
+        "information",
+        "safety",
+        "safe",
+        "prepare",
+        "prepared",
+        "preparedness",
+        "before",
+        "during",
+        "after",
+        "warning",
+        "evacuate",
+        "evacuation",
+        "shelter",
+        "cleanup",
+        "clean up",
+        "insurance",
+        "claim",
+        "coverage",
+        "resource",
+        "resources",
+        "link",
+        "learn more",
+        "where can i",
+        "ready.gov",
+        "ready gov",
+        "fema",
+    ]
+    data_query_terms = [
+        "dataset",
+        "scene",
+        "xbd",
+        "building",
+        "buildings",
+        "damage count",
+        "how many",
+        "show",
+        "map",
+        "classified",
+        "predicted",
+    ]
+
+    has_guidance_language = any(term in q for term in guidance_terms)
+    has_location_data_language = (
+        any(term in q for term in ["near ", " in ", " on ", " around ", " at "])
+        and any(term in q for term in ["damage", "building", "buildings", "dataset", "scene", "xbd", "classified", "predicted"])
+    )
+    has_data_language = any(term in q for term in data_query_terms) or has_location_data_language
+    if has_data_language and "fema" not in q and "ready" not in q:
+        return False
+    return has_guidance_language or not has_data_language
+
+
+def load_disaster_guidance_markdown(topic):
+    metadata = DISASTER_GUIDANCE_TOPICS.get(topic)
+    if not metadata:
+        return ""
+
+    try:
+        return metadata["path"].read_text(encoding="utf-8")
+    except OSError:
+        logger.warning("Could not read disaster guidance markdown for topic %s", topic)
+        return ""
+
+
+def clean_markdown_heading(line):
+    return re.sub(r"[*_`#]+", "", line).strip(" :-")
+
+
+def split_markdown_sections(markdown_text):
+    lines = markdown_text.splitlines()
+    sections = []
+    current_title = "Overview"
+    current_lines = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        next_line = lines[index + 1].strip() if index + 1 < len(lines) else ""
+        is_setext_heading = bool(stripped and re.fullmatch(r"[=-]{3,}", next_line))
+        is_atx_heading = stripped.startswith("#")
+
+        if is_atx_heading or is_setext_heading:
+            if current_lines:
+                sections.append((current_title, "\n".join(current_lines).strip()))
+                current_lines = []
+            current_title = clean_markdown_heading(stripped)
+            index += 2 if is_setext_heading else 1
+            continue
+
+        current_lines.append(line)
+        index += 1
+
+    if current_lines:
+        sections.append((current_title, "\n".join(current_lines).strip()))
+
+    return [
+        (title, content)
+        for title, content in sections
+        if content
+    ]
+
+
+def guidance_section_keywords(section):
+    return {
+        "overview": ["overview", "floods", "hurricanes"],
+        "before": ["before", "prepare", "plan", "supplies", "documents"],
+        "during": ["during", "warning", "evacuate", "shelter", "trapped"],
+        "after": ["after", "cleanup", "return", "recover"],
+        "alerts": ["alert", "alerts", "warning", "weather radio", "fema app"],
+        "insurance": ["insurance", "claim", "coverage", "nfip"],
+        "resources": ["resources", "partner resources", "additional resources"],
+    }.get(section, ["overview"])
+
+
+def select_guidance_sections(markdown_text, section):
+    sections = split_markdown_sections(markdown_text)
+    keywords = guidance_section_keywords(section)
+    selected = []
+
+    for title, content in sections:
+        searchable = f"{title}\n{content}".lower()
+        if any(keyword in searchable for keyword in keywords):
+            selected.append((title, content))
+
+    if not selected:
+        selected = sections[:2]
+
+    return selected[:3]
+
+
+def truncate_context(text, max_chars=6500):
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rsplit("\n", 1)[0].strip()
+
+
+def build_disaster_guidance_context(question):
+    detected_topics = detect_disaster_guidance_topics(question)
+    section = detect_disaster_guidance_section(question)
+    topics = detected_topics if detected_topics else list(DISASTER_GUIDANCE_TOPICS.keys())
+    blocks = []
+
+    for topic_name in topics:
+        metadata = DISASTER_GUIDANCE_TOPICS[topic_name]
+        markdown_text = load_disaster_guidance_markdown(topic_name)
+        if not markdown_text:
+            continue
+
+        selected_sections = select_guidance_sections(markdown_text, section)
+        section_blocks = [
+            f"## {title}\n{content}"
+            for title, content in selected_sections
+        ]
+        blocks.append("\n".join([
+            f"Source: {metadata['source']}",
+            f"URL: {metadata['url']}",
+            *section_blocks,
+        ]))
+
+    return truncate_context("\n\n---\n\n".join(blocks))
+
+
+def disaster_guidance_sources(question):
+    detected_topics = detect_disaster_guidance_topics(question)
+    topics = detected_topics if detected_topics else list(DISASTER_GUIDANCE_TOPICS.keys())
+    return [
+        f"{DISASTER_GUIDANCE_TOPICS[topic_name]['source']} ({DISASTER_GUIDANCE_TOPICS[topic_name]['url']})"
+        for topic_name in topics
+    ]
+
+
+def fallback_disaster_guidance_response(question, context):
+    if not context:
+        return (
+            "I can answer general disaster guidance questions when the Ready.gov guidance files are available. "
+            + DISASTER_GUIDANCE_SAFETY_MESSAGE
+        )
+
+    lines = [
+        re.sub(r"\s+", " ", line.strip(" *"))
+        for line in context.splitlines()
+        if line.strip().startswith("*")
+    ]
+    excerpt_lines = lines[:4]
+    if not excerpt_lines:
+        excerpt_lines = [
+            re.sub(r"\s+", " ", line.strip())
+            for line in context.splitlines()
+            if line.strip() and not line.startswith(("Source:", "URL:", "##", "---"))
+        ][:4]
+
+    sources = "; ".join(disaster_guidance_sources(question))
+    return "\n".join([
+        "I could not reach the LLM, but these Ready.gov excerpts may help:",
+        *[f"- {line}" for line in excerpt_lines],
+        DISASTER_GUIDANCE_SAFETY_MESSAGE,
+        f"Sources: {sources}.",
+    ])
+
+
+def disaster_guidance_response(question):
+    context = build_disaster_guidance_context(question)
+    sources = "; ".join(disaster_guidance_sources(question))
+    prompt = f"""
+You are Hazardly, a disaster damage assessment chatbot.
+
+Answer the user's general disaster guidance question using only the Ready.gov/FEMA source excerpts below.
+
+User question: {question}
+
+Source excerpts:
+{context}
+
+Rules:
+- Use only the source excerpts. Do not invent guidance.
+- Keep the answer concise and practical.
+- Prefer 3-5 short bullet points.
+- Include "{DISASTER_GUIDANCE_SAFETY_MESSAGE}"
+- End with "Sources: {sources}."
+- Do not mention prompts, markdown, hidden context, or database details.
+"""
+
+    answer = call_nemotron(prompt)
+    if not answer:
+        return fallback_disaster_guidance_response(question, context)
+
+    cleaned_answer = str(answer).strip().strip('"')
+    if DISASTER_GUIDANCE_SAFETY_MESSAGE.lower() not in cleaned_answer.lower():
+        cleaned_answer = f"{cleaned_answer}\n{DISASTER_GUIDANCE_SAFETY_MESSAGE}"
+    if "sources:" not in cleaned_answer.lower():
+        cleaned_answer = f"{cleaned_answer}\nSources: {sources}."
+    return cleaned_answer
 
 
 
@@ -2517,14 +2854,14 @@ def is_acknowledgement_query(question):
 def greeting_response():
     return (
         "Hi, I am Hazardly. Ask me about disaster damage counts, affected cities, damaged buildings near a "
-        "location, xBD scenes, or safety and repair guidance from the active dataset."
+        "location, xBD scenes, or general flood and hurricane safety guidance."
     )
 
 
 def identity_response():
     return (
         "I am Hazardly, a disaster damage assessment assistant for the active dataset. I can help with damage "
-        "counts, affected cities, damaged buildings near a location, xBD scenes, and safety or repair guidance."
+        "counts, affected cities, damaged buildings near a location, xBD scenes, and general flood or hurricane guidance."
     )
 
 
@@ -2536,18 +2873,18 @@ def help_response():
     options = [
         "\n".join([
             "I can help with disaster damage assessment questions for the active dataset.",
-            "Try asking for a dataset summary, affected cities, damage counts, damaged buildings near a city or address, a specific xBD scene, misclassified buildings, or safety/repair guidance based on nearby damage levels.",
-            "Examples: \"Show major damage near Houston\", \"Summarize damage in Sugar Land\", or \"What cities have the most major damage?\"",
+            "Try asking for a dataset summary, affected cities, damage counts, damaged buildings near a city or address, a specific xBD scene, misclassified buildings, or general flood and hurricane safety guidance.",
+            "Examples: \"Show major damage near Houston\", \"Summarize damage in Sugar Land\", or \"What should I do during a flood?\"",
         ]),
         "\n".join([
             "I can help you explore damage patterns in the active disaster dataset.",
-            "You can ask about affected cities, scene-level damage, building counts by severity, misclassified buildings, or conditions near a city, area, address, or xBD scene.",
-            "Examples: \"What happened to Richmond?\", \"Show scene 18\", or \"Which cities have the most destroyed buildings?\"",
+            "You can ask about affected cities, scene-level damage, building counts by severity, misclassified buildings, Ready.gov flood or hurricane guidance, or conditions near a city, area, address, or xBD scene.",
+            "Examples: \"What happened to Richmond?\", \"Show scene 18\", or \"How should I prepare for a hurricane?\"",
         ]),
         "\n".join([
             "I am best at answering questions about disaster damage assessment data.",
-            "Ask me to summarize the dataset, compare locations, list affected cities, find damaged buildings, explain damage labels, or give safety and repair guidance based on nearby damage.",
-            "Examples: \"Summarize the full dataset\", \"Compare Missouri City and Cypress\", or \"What damage labels exist?\"",
+            "Ask me to summarize the dataset, compare locations, list affected cities, find damaged buildings, explain damage labels, or give general flood and hurricane guidance.",
+            "Examples: \"Summarize the full dataset\", \"Compare Missouri City and Cypress\", or \"What should I do after a hurricane?\"",
         ]),
     ]
 
@@ -2578,19 +2915,21 @@ def unsupported_query_response():
     return (
         "I understand this is related to disaster damage assessment, but I have not been taught how to answer that "
         "kind of request yet. Try asking about damage counts, affected cities, damaged buildings near a location, "
-        "xBD scenes, or safety and repair guidance from the active dataset."
+        "xBD scenes, or general flood and hurricane safety guidance."
     )
 
 
 def out_of_scope_query_response():
     return (
         "That is outside my disaster damage assessment scope. I can help with damage counts, affected cities, "
-        "damaged buildings near a location, xBD scenes, or safety and repair guidance from the active dataset."
+        "damaged buildings near a location, xBD scenes, or general flood and hurricane safety guidance."
     )
 
 
 def is_untrained_disaster_request(question):
     q = question.lower()
+    if is_disaster_guidance_query(question):
+        return False
     if "predicted damage" in q:
         return False
     unsupported_terms = [
@@ -2639,6 +2978,9 @@ def classify_query_intent_heuristic(question):
 
     if is_help_query(question):
         return "help"
+
+    if is_disaster_guidance_query(question):
+        return "disaster_guidance"
 
     if is_untrained_disaster_request(question):
         return "unsupported"
@@ -2733,6 +3075,7 @@ Choose exactly one label from this list:
 - acknowledgement
 - active_disaster
 - help
+- disaster_guidance
 - location_comparison
 - location_percentage
 - conversation_summary
@@ -2757,6 +3100,7 @@ Definitions:
 - acknowledgement: brief thanks or acknowledgement after the assistant has answered
 - active_disaster: asks which active disaster or disaster dataset is being viewed
 - help: asks what the assistant can do or what questions are supported
+- disaster_guidance: asks for general flood, hurricane, Ready.gov, or FEMA preparedness/safety/recovery guidance, without asking for active dataset counts or map results
 - location_comparison: compares two named locations
 - location_percentage: asks what percentage/share of buildings in a place fit a damage level
 - conversation_summary: asks for a recap of the conversation
@@ -2779,6 +3123,12 @@ Label: city_list
 
 Question: What can you help with?
 Label: help
+
+Question: What should I do during a flood?
+Label: disaster_guidance
+
+Question: How should I prepare for a hurricane?
+Label: disaster_guidance
 
 Question: What disaster is this?
 Label: active_disaster
@@ -2830,6 +3180,7 @@ Label:
         "acknowledgement",
         "active_disaster",
         "help",
+        "disaster_guidance",
         "location_comparison",
         "location_percentage",
         "conversation_summary",
@@ -2978,6 +3329,7 @@ def parse_structured_query(question):
         "acknowledgement": "acknowledgement",
         "active_disaster": "active_disaster",
         "help": "help",
+        "disaster_guidance": "disaster_guidance",
         "location_comparison": "location_comparison",
         "location_percentage": "location_percentage",
         "conversation_summary": "conversation_summary",
@@ -3111,6 +3463,7 @@ def parse_structured_query(question):
         "acknowledgement",
         "active_disaster",
         "help",
+        "disaster_guidance",
         "conversation_summary",
         "scene_count",
         "scene_ranking",
@@ -3341,6 +3694,17 @@ def handle_chat_query(question, session_id=None):
 
     if intent == "help":
         answer = help_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()
+        }
+
+    if intent == "disaster_guidance":
+        answer = disaster_guidance_response(question)
         save_turn(question, answer)
         return {
             "answer": answer,

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -855,6 +855,8 @@ def resolve_location_buildings(location_text):
 
 
 def filter_buildings_by_damage(buildings, damage_type):
+    if damage_type == "damaged":
+        return [b for b in buildings if b.get("damage") != "no-damage"]
     return [b for b in buildings if b.get("damage") == damage_type]
 
 
@@ -931,11 +933,40 @@ def is_city_ranking_query(question):
         "hardest-hit",
         "hardest hit",
         "hit hardest",
+        "impacted the most",
+        "most impacted",
+        "affected the most",
+        "most affected",
         "where is major damage concentrated",
         "which cities have",
         "what areas have",
     ]
     return any(signal in q for signal in ranking_signals)
+
+
+def is_repair_count_query(question):
+    q = question.lower()
+    return (
+        any(term in q for term in ["how many", "count", "number of"])
+        and any(term in q for term in ["need repair", "need to be repaired", "repaired", "repair"])
+    )
+
+
+def is_location_damage_display_query(question):
+    q = question.lower()
+    if extract_xbd_query_id(question) is not None:
+        return False
+    action_terms = ["show", "show me", "display", "list", "find"]
+    if not any(term in q for term in action_terms):
+        return False
+    if "damage" not in q:
+        return False
+
+    return bool(
+        extract_on_location_text(question)
+        or extract_in_location_text(question)
+        or re.search(r"\bnear\s+.+", question, flags=re.IGNORECASE)
+    )
 
 
 def is_scene_count_query(question):
@@ -1011,7 +1042,16 @@ def get_ranking_metric(question):
         return "least-severe-damage"
     if any(term in q for term in ["destroyed", "hardest-hit", "hardest hit", "hit hardest"]):
         return "destroyed"
-    if any(term in q for term in ["most damaged", "most damage", "worst damage", "worst damaged"]):
+    if any(term in q for term in [
+        "most damaged",
+        "most damage",
+        "worst damage",
+        "worst damaged",
+        "impacted the most",
+        "most impacted",
+        "affected the most",
+        "most affected",
+    ]):
         return "severe-damage"
     if "major" in q:
         return "major-damage"
@@ -1727,6 +1767,79 @@ def get_full_dataset_damage_counts():
     return counts
 
 
+def get_full_dataset_metadata():
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    WITH building_cities AS (
+      SELECT DISTINCT
+        CASE
+          WHEN TRIM(SPLIT_PART(address, ',', 2)) ~* '[0-9]'
+            OR LOWER(TRIM(SPLIT_PART(address, ',', 2))) IN ('texas', 'tx')
+          THEN TRIM(SPLIT_PART(address, ',', 1))
+          ELSE TRIM(SPLIT_PART(address, ',', 2))
+        END AS city
+      FROM buildings
+      WHERE address IS NOT NULL
+        AND POSITION(',' IN address) > 0
+    )
+    SELECT
+      (SELECT COUNT(*) FROM disasters) AS disaster_count,
+      (SELECT COUNT(*) FROM image_pairs) AS image_pair_count,
+      (SELECT COUNT(*) FROM buildings) AS building_count,
+      (
+        SELECT COUNT(*)
+        FROM building_cities
+        WHERE city <> ''
+          AND city !~* '^[0-9]+$'
+      ) AS city_count,
+      (
+        SELECT COUNT(*)
+        FROM buildings
+        WHERE predicted_damage IS NOT NULL
+      ) AS predicted_count,
+      (
+        SELECT COUNT(*)
+        FROM buildings
+        WHERE actual_damage IS NOT NULL
+      ) AS labeled_count,
+      (
+        SELECT COUNT(*)
+        FROM buildings
+        WHERE predicted_damage IS NOT NULL
+          AND actual_damage IS NOT NULL
+      ) AS compared_count,
+      (
+        SELECT COUNT(*)
+        FROM buildings
+        WHERE predicted_damage IS NOT NULL
+          AND actual_damage IS NOT NULL
+          AND actual_damage::text = predicted_damage::text
+      ) AS correct_count
+    """
+
+    cur.execute(query)
+    row = cur.fetchone()
+
+    cur.close()
+    conn.close()
+
+    if not row:
+        return {}
+
+    return {
+        "disaster_count": int(row[0] or 0),
+        "image_pair_count": int(row[1] or 0),
+        "building_count": int(row[2] or 0),
+        "city_count": int(row[3] or 0),
+        "predicted_count": int(row[4] or 0),
+        "labeled_count": int(row[5] or 0),
+        "compared_count": int(row[6] or 0),
+        "correct_count": int(row[7] or 0),
+    }
+
+
 def count_damage_levels(buildings):
     counts = {level: 0 for level in DAMAGE_LEVELS}
 
@@ -1756,7 +1869,70 @@ def format_damage_count_response(counts, location_text):
     return response + "."
 
 
-def format_damage_bullet_summary(counts, location_text):
+def format_number(value):
+    return f"{value:,}"
+
+
+def format_percentage(count, total):
+    if total <= 0:
+        return "0%"
+
+    return f"{round((count / total) * 100, 1)}%"
+
+
+def format_damage_summary_line(label, count, total):
+    return f"- {label}: {format_number(count)} ({format_percentage(count, total)})"
+
+
+def format_full_dataset_context_lines(metadata, counts):
+    if not metadata:
+        return []
+
+    total = sum(counts.values())
+    lines = []
+    disaster_count = metadata.get("disaster_count", 0)
+    image_pair_count = metadata.get("image_pair_count", 0)
+    city_count = metadata.get("city_count", 0)
+    compared_count = metadata.get("compared_count", 0)
+    correct_count = metadata.get("correct_count", 0)
+
+    if disaster_count or image_pair_count or city_count:
+        scope_parts = []
+        if disaster_count:
+            scope_parts.append(f"{format_number(disaster_count)} disaster dataset")
+        if image_pair_count:
+            scope_parts.append(f"{format_number(image_pair_count)} xBD scenes/image pairs")
+        if city_count:
+            scope_parts.append(f"{format_number(city_count)} cities or named locations with address data")
+        lines.append(f"- Scope: {', '.join(scope_parts)}")
+
+    severe_total = counts.get("major-damage", 0) + counts.get("destroyed", 0)
+    if total > 0:
+        lines.append(
+            f"- Severe damage: {format_number(severe_total)} buildings ({format_percentage(severe_total, total)}) are major-damage or destroyed"
+        )
+
+        dominant_key, dominant_count = max(counts.items(), key=lambda item: item[1])
+        dominant_label = {
+            "no-damage": "No damage",
+            "minor-damage": "Minor damage",
+            "major-damage": "Major damage",
+            "destroyed": "Destroyed",
+        }.get(dominant_key, dominant_key.replace("-", " "))
+        lines.append(
+            f"- Largest class: {dominant_label} ({format_number(dominant_count)}, {format_percentage(dominant_count, total)})"
+        )
+
+    if compared_count > 0:
+        accuracy = format_percentage(correct_count, compared_count)
+        lines.append(
+            f"- Prediction evaluation: {format_number(correct_count)} of {format_number(compared_count)} comparable predictions are correct ({accuracy})"
+        )
+
+    return lines
+
+
+def format_damage_bullet_summary(counts, location_text, metadata=None):
     total = sum(counts.values())
 
     if total == 0:
@@ -1772,21 +1948,23 @@ def format_damage_bullet_summary(counts, location_text):
 
     lines = [
         f"Here's the dataset summary for {location_text}:",
-        f"- Total buildings: {total}",
-        f"- No damage: {counts.get('no-damage', 0)}",
-        f"- Minor damage: {counts.get('minor-damage', 0)}",
-        f"- Major damage: {counts.get('major-damage', 0)}",
-        f"- Destroyed: {counts.get('destroyed', 0)}",
+        f"- Total buildings: {format_number(total)}",
+        format_damage_summary_line("No damage", counts.get("no-damage", 0), total),
+        format_damage_summary_line("Minor damage", counts.get("minor-damage", 0), total),
+        format_damage_summary_line("Major damage", counts.get("major-damage", 0), total),
+        format_damage_summary_line("Destroyed", counts.get("destroyed", 0), total),
     ]
 
     if other_total > 0:
-        lines.append(f"- Other or unlabeled: {other_total}")
+        lines.append(format_damage_summary_line("Other or unlabeled", other_total, total))
+
+    lines.extend(format_full_dataset_context_lines(metadata, counts))
 
     return "\n".join(lines)
 
 
-def synthesize_location_overview_answer(location_text, counts):
-    return format_damage_bullet_summary(counts, location_text)
+def synthesize_location_overview_answer(location_text, counts, metadata=None):
+    return format_damage_bullet_summary(counts, location_text, metadata)
 
 
 
@@ -2200,6 +2378,14 @@ def is_city_list_query(question):
         "which cities were affected",
         "what cities were affected",
         "which cities are affected",
+        "what cities were evaluated",
+        "which cities were evaluated",
+        "what cities have been evaluated",
+        "which cities have been evaluated",
+        "what cities do you know about",
+        "which cities do you know about",
+        "what cities can you tell me about",
+        "which cities can you tell me about",
         "list the affected cities",
         "list cities in the dataset",
         "list cities in the data",
@@ -2388,6 +2574,8 @@ def out_of_scope_query_response():
 
 def is_untrained_disaster_request(question):
     q = question.lower()
+    if "predicted damage" in q:
+        return False
     unsupported_terms = [
         "forecast",
         "predict",
@@ -2433,6 +2621,9 @@ def classify_query_intent_heuristic(question):
 
     if is_vlm_query(question):
         return "vlm"
+
+    if is_location_damage_display_query(question):
+        return "location_query"
 
     if is_scene_count_query(question):
         return "scene_count"
@@ -2660,6 +2851,25 @@ def classify_query_intent(question):
 
 def extract_damage_filter(question):
     q = question.lower()
+    if is_repair_count_query(question):
+        return "damaged"
+    has_specific_damage_label = any(term in q for term in [
+        "fine",
+        "no damage",
+        "no-damage",
+        "no damaged",
+        "undamaged",
+        "unaffected",
+        "non-damaged",
+        "non damaged",
+        "not damaged",
+        "minor",
+        "destroyed",
+        "major",
+        "damaged",
+    ])
+    if "predicted damage" in q and not has_specific_damage_label:
+        return None
     if any(word in q for word in [
         "fine", "no damage", "no-damage", "no damaged", "undamaged", "unaffected",
         "non-damaged", "non damaged", "not damaged"
@@ -2669,7 +2879,11 @@ def extract_damage_filter(question):
         return "minor-damage"
     if "destroyed" in q:
         return "destroyed"
-    if "major" in q or "damaged" in q or "damage" in q:
+    if "major" in q:
+        return "major-damage"
+    if "damaged" in q:
+        return "damaged"
+    if "damage" in q:
         return "major-damage"
     return None
 
@@ -3386,16 +3600,20 @@ def handle_chat_query(question, session_id=None):
     # full dataset summary does not have a single map focus
     if intent == "dataset_overview":
         counts = get_full_dataset_damage_counts()
+        try:
+            metadata = get_full_dataset_metadata()
+        except Exception:
+            metadata = None
         parsed_damage_filter = parsed_query["damage_filter"]
         damage_key = parsed_damage_filter if isinstance(parsed_damage_filter, str) else None
         damage_label = get_damage_label_text(damage_key)
         if damage_key and damage_label and damage_key in counts:
             answer = "\n".join([
                 f"Here's the dataset summary for {damage_label} buildings:",
-                f"- Total {damage_label} buildings: {counts.get(damage_key, 0)}",
+                f"- Total {damage_label} buildings: {format_number(counts.get(damage_key, 0))}",
             ])
         else:
-            answer = synthesize_location_overview_answer("the full dataset", counts)
+            answer = synthesize_location_overview_answer("the full dataset", counts, metadata)
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -3472,8 +3690,10 @@ def handle_chat_query(question, session_id=None):
     if intent == "location_query" and parsed_query["query_mode"] == "on_address" and primary_location:
         on_location_text = primary_location
         has_explicit_region = "," in on_location_text
-        requested_damage = None if wants_all_buildings else damage_type
+        requested_damage = None if wants_all_buildings or damage_type == "damaged" else damage_type
         buildings = get_buildings_on_address_text(on_location_text, requested_damage)
+        if damage_type == "damaged" and not wants_all_buildings:
+            buildings = filter_buildings_by_damage(buildings, damage_type)
         primary_xbd_id = get_dominant_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
         geo = geocode_address(on_location_text) if has_explicit_region else None
@@ -3497,6 +3717,8 @@ def handle_chat_query(question, session_id=None):
         if wants_all_buildings:
             counts = count_damage_levels(buildings)
             answer = synthesize_location_overview_answer(f"addresses on {label_text}", counts)
+        elif damage_type == "damaged":
+            answer = f"{len(buildings)} buildings on {label_text} are classified as damaged."
         elif damage_type == "no-damage":
             answer = f"{len(buildings)} buildings on {label_text} appear to have no visible damage."
         else:
@@ -3562,19 +3784,33 @@ def handle_chat_query(question, session_id=None):
 
     if intent == "location_query" and parsed_query["query_mode"] == "in_location" and primary_location:
         in_location_text = primary_location
-        geo = geocode_address(in_location_text)
+        city_lookup_buildings = []
+        if "," not in in_location_text and not looks_like_street_address(in_location_text):
+            city_lookup_buildings = get_all_buildings_for_city(in_location_text)
+
+        geo = None if city_lookup_buildings else geocode_address(in_location_text)
         buildings = []
-        if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
+        if city_lookup_buildings:
+            buildings = city_lookup_buildings
+        elif geo and geo.get("bbox") and len(geo["bbox"]) == 4:
             min_lon, min_lat, max_lon, max_lat = geo["bbox"]
-            buildings = get_buildings_in_bbox(
-                min_lon,
-                min_lat,
-                max_lon,
-                max_lat,
-                damage_type,
-            )
+            if damage_type == "damaged":
+                buildings = get_all_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat)
+            else:
+                buildings = get_buildings_in_bbox(
+                    min_lon,
+                    min_lat,
+                    max_lon,
+                    max_lat,
+                    damage_type,
+                )
         if len(buildings) == 0:
-            buildings = get_buildings_by_address_text(in_location_text, damage_type)
+            address_damage_filter = None if damage_type == "damaged" else damage_type
+            buildings = get_buildings_by_address_text(in_location_text, address_damage_filter)
+        if len(buildings) == 0 and "," not in in_location_text:
+            buildings = get_all_buildings_for_city(in_location_text)
+        if damage_type == "damaged":
+            buildings = filter_buildings_by_damage(buildings, damage_type)
         primary_xbd_id = get_dominant_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
 
@@ -3590,7 +3826,9 @@ def handle_chat_query(question, session_id=None):
             }
 
         label_text = geo["formatted_address"] if geo else in_location_text
-        if damage_type == "no-damage":
+        if damage_type == "damaged":
+            answer = f"{len(buildings)} buildings in {label_text} are classified as damaged and may need repair."
+        elif damage_type == "no-damage":
             answer = f"{len(buildings)} buildings in {label_text} appear to have no visible damage."
         else:
             answer = generate_llm_answer(buildings, label_text, damage_type)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -203,6 +203,12 @@ def extract_general_location_text(question):
             location_text,
             flags=re.IGNORECASE,
         ).strip(" ,")
+        location_text = re.sub(
+            r"^(?:the\s+)?city\s+of\s+",
+            "",
+            location_text,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
         return location_text or None
 
     return None
@@ -546,26 +552,13 @@ def resolve_location_buildings(location_text):
     has_explicit_region = "," in normalized_location
     geocode_query = normalized_location
 
-    if not has_explicit_region:
-        buildings = get_all_buildings_by_address_text(normalized_location)
-        if len(buildings) > 0:
-            if looks_like_street_address(normalized_location):
-                return None, normalized_location, buildings
-
-            geo = geocode_address(
-                f"{normalized_location}, Texas"
-                if DEFAULT_DISASTER_NAME == "hurricane-harvey"
-                else normalized_location
-            )
-            label_text = geo["formatted_address"] if geo else normalized_location
-            return geo, label_text, buildings
-        if DEFAULT_DISASTER_NAME == "hurricane-harvey":
-            geocode_query = f"{normalized_location}, Texas"
-
     if looks_like_exact_address(normalized_location):
         buildings = get_buildings_on_address_text(normalized_location, None)
         if len(buildings) > 0:
             return None, normalized_location, buildings
+
+    if not has_explicit_region and DEFAULT_DISASTER_NAME == "hurricane-harvey":
+        geocode_query = f"{normalized_location}, Texas"
 
     geo = geocode_address(geocode_query)
     buildings = []
@@ -582,6 +575,13 @@ def resolve_location_buildings(location_text):
             geo["lat"],
             STREET_ADDRESS_OVERVIEW_RADIUS_M,
         )
+    elif not has_explicit_region and not looks_like_street_address(normalized_location):
+        city_label = (
+            geo["formatted_address"].split(",")[0].strip()
+            if geo and geo.get("formatted_address")
+            else normalized_location
+        )
+        buildings = get_all_buildings_for_city(city_label)
     elif geo and geo.get("bbox") and len(geo["bbox"]) == 4:
         min_lon, min_lat, max_lon, max_lat = geo["bbox"]
         buildings = get_all_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat)
@@ -625,6 +625,9 @@ def extract_comparison_locations(question):
         r"compare\s+(.+?)\s+to\s+(.+?)(?:\?|$)",
         r"which is worse,\s+(.+?)\s+or\s+(.+?)(?:\?|$)",
         r"which is worse:\s+(.+?)\s+or\s+(.+?)(?:\?|$)",
+        r"tell me about\s+(.+?)\s+and\s+(.+?)(?:\?|$)",
+        r"what about\s+(.+?)\s+and\s+(.+?)(?:\?|$)",
+        r"overview of\s+(.+?)\s+and\s+(.+?)(?:\?|$)",
     ]
 
     for pattern in patterns:
@@ -633,6 +636,18 @@ def extract_comparison_locations(question):
             continue
         first = match.group(1).strip(" ?,.")
         second = match.group(2).strip(" ?,.")
+        first = re.sub(
+            r"^(?:the\s+)?cities?\s+of\s+",
+            "",
+            first,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
+        second = re.sub(
+            r"^(?:the\s+)?cities?\s+of\s+",
+            "",
+            second,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
         if first and second:
             return first, second
 
@@ -641,7 +656,13 @@ def extract_comparison_locations(question):
 
 def is_city_comparison_query(question):
     q = question.lower()
-    return "compare " in q or "which is worse" in q
+    return (
+        "compare " in q
+        or "which is worse" in q
+        or "tell me about" in q
+        or "what about" in q
+        or "overview of" in q
+    )
 
 
 def is_city_ranking_query(question):
@@ -1053,6 +1074,50 @@ def get_all_buildings_by_address_text(address_text):
     return rows_to_buildings(rows)
 
 
+def get_all_buildings_for_city(city_text):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    normalized_city = city_text.strip()
+    if not normalized_city:
+        cur.close()
+        conn.close()
+        return []
+
+    query = """
+    WITH building_cities AS (
+      SELECT
+        b.uid,
+        ip.xbd_id,
+        b.predicted_damage,
+        ST_AsGeoJSON(b.geom) AS geometry,
+        CASE
+          WHEN TRIM(SPLIT_PART(b.address, ',', 2)) ~* '[0-9]'
+            OR LOWER(TRIM(SPLIT_PART(b.address, ',', 2))) IN ('texas', 'tx')
+          THEN TRIM(SPLIT_PART(b.address, ',', 1))
+          ELSE TRIM(SPLIT_PART(b.address, ',', 2))
+        END AS city
+      FROM buildings b
+      JOIN image_pairs ip ON b.image_pair_id = ip.id
+      JOIN disasters d ON ip.disaster_id = d.id
+      WHERE b.address IS NOT NULL
+        AND d.name = %s
+        AND POSITION(',' IN b.address) > 0
+    )
+    SELECT uid, xbd_id, predicted_damage, geometry
+    FROM building_cities
+    WHERE LOWER(city) = LOWER(%s)
+    """
+
+    cur.execute(query, (DEFAULT_DISASTER_NAME, normalized_city))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
 def build_map_action_from_buildings(buildings, address_text=None, primary_xbd_id=None):
     primary_xbd_id = primary_xbd_id if primary_xbd_id is not None else get_primary_xbd_id(buildings)
 
@@ -1176,7 +1241,8 @@ def get_full_dataset_damage_counts():
     }
 
     for damage, count in rows:
-        counts[damage] = count
+        if damage in counts:
+            counts[damage] = count
 
     return counts
 
@@ -1255,23 +1321,7 @@ def format_damage_bullet_summary(counts, location_text):
 
 
 def synthesize_location_overview_answer(location_text, counts):
-    fallback = format_damage_bullet_summary(counts, location_text)
-    prompt = f"""
-You are Hazardly, a disaster damage assessment assistant.
-
-Use only these exact facts:
-Location: {location_text}
-Counts: {counts}
-
-Write a concise answer for the user.
-
-Rules:
-- Use 3 to 5 short bullet points.
-- Mention the total buildings and the key damage breakdown.
-- Do not invent extra numbers.
-- Do not mention databases, SQL, retrieval, tools, or models.
-"""
-    return synthesize_structured_answer(prompt, fallback)
+    return format_damage_bullet_summary(counts, location_text)
 
 
 
@@ -1673,6 +1723,146 @@ def is_damage_label_query(question):
     ])
 
 
+def classify_query_intent_heuristic(question):
+    if is_vlm_query(question):
+        return "vlm"
+
+    if is_conversation_summary_query(question):
+        return "conversation_summary"
+
+    if is_city_count_query(question):
+        return "city_count"
+
+    if is_damage_label_query(question):
+        return "damage_labels"
+
+    if is_city_list_query(question):
+        return "city_list"
+
+    if is_city_ranking_query(question):
+        return "city_ranking"
+
+    comparison_locations = extract_comparison_locations(question)
+    if comparison_locations and is_city_comparison_query(question):
+        return "location_comparison"
+
+    if extract_percentage_location_text(question):
+        return "location_percentage"
+
+    if is_full_dataset_query(question):
+        return "full_dataset_summary"
+
+    if extract_xbd_query_id(question) is not None:
+        return "xbd_query"
+
+    if extract_general_location_text(question):
+        return "general_location_overview"
+
+    return None
+
+
+def classify_query_intent_llm(question):
+    prompt = f"""
+You are routing user questions for a disaster damage assessment assistant.
+
+Choose exactly one label from this list:
+- full_dataset_summary
+- city_list
+- city_count
+- damage_labels
+- city_ranking
+- location_comparison
+- location_percentage
+- conversation_summary
+- vlm
+- xbd_query
+- general_location_overview
+- location_query
+- unsupported
+
+Definitions:
+- full_dataset_summary: asks about the dataset as a whole, what the data contains, or overall damage across the dataset, without focusing on one place
+- city_list: asks which cities or locations appear in the dataset
+- city_count: asks how many cities or locations are represented
+- damage_labels: asks which damage labels or levels exist
+- city_ranking: asks which cities have the most or least damage
+- location_comparison: compares two named locations
+- location_percentage: asks what percentage/share of buildings in a place fit a damage level
+- conversation_summary: asks for a recap of the conversation
+- vlm: asks about uploading, evaluating, or comparing images
+- xbd_query: directly references an xBD scene ID
+- general_location_overview: asks for an overview or summary of damage in one place
+- location_query: asks about buildings or damage for one place, address, area, or scene, including map-like requests
+- unsupported: not related to disaster damage assessment
+
+Examples:
+Question: Tell me about the data
+Label: full_dataset_summary
+
+Question: What does this dataset contain?
+Label: full_dataset_summary
+
+Question: What cities are in the dataset?
+Label: city_list
+
+Question: Compare Houston and Sugar Land
+Label: location_comparison
+
+Question: Show destroyed buildings near downtown Houston
+Label: location_query
+
+Question: Summarize damage in Sugar Land
+Label: general_location_overview
+
+Question: Show XBD 18
+Label: xbd_query
+
+Question: Upload a before and after image
+Label: vlm
+
+Question: {question}
+Label:
+"""
+
+    result = call_nemotron(prompt)
+    if not result:
+        return None
+
+    label = result.strip().strip('"').strip().splitlines()[0].strip().lower()
+    valid_labels = {
+        "full_dataset_summary",
+        "city_list",
+        "city_count",
+        "damage_labels",
+        "city_ranking",
+        "location_comparison",
+        "location_percentage",
+        "conversation_summary",
+        "vlm",
+        "xbd_query",
+        "general_location_overview",
+        "location_query",
+        "unsupported",
+    }
+
+    return label if label in valid_labels else None
+
+
+def classify_query_intent(question):
+    heuristic_intent = classify_query_intent_heuristic(question)
+    if heuristic_intent:
+        return heuristic_intent
+
+    llm_intent = classify_query_intent_llm(question)
+    if llm_intent:
+        return llm_intent
+
+    if is_disaster_related(question):
+        return "location_query"
+
+    return "unsupported"
+
+
 def format_city_damage_stats(rows):
     if len(rows) == 0:
         return "I couldn't find any city-level address data in the dataset."
@@ -1839,8 +2029,9 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
 
-    # detect VLM/image-related queries
-    if is_vlm_query(question):
+    intent = classify_query_intent(question)
+
+    if intent == "vlm":
         answer = vlm_guidance_response()
         save_turn(question, answer)
         return {
@@ -1851,8 +2042,7 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
 
-    # conversation summary
-    if is_conversation_summary_query(question):
+    if intent == "conversation_summary":
         answer = summarize_conversation()
         save_turn(question, answer)
         return {
@@ -1863,7 +2053,7 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
 
-    if is_city_count_query(question):
+    if intent == "city_count":
         rows = fetch_city_damage_stats(limit=500)
         city_total = len(rows)
         answer = (
@@ -1878,7 +2068,7 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    if is_damage_label_query(question):
+    if intent == "damage_labels":
         answer = "\n".join([
             "The dataset uses these damage labels:",
             "- No damage",
@@ -1895,7 +2085,7 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    if is_city_list_query(question):
+    if intent == "city_list":
         rows = fetch_city_damage_stats()
         answer = synthesize_city_damage_stats_answer(rows)
         save_turn(question, answer)
@@ -1907,7 +2097,7 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    if is_city_ranking_query(question):
+    if intent == "city_ranking":
         rows = fetch_city_damage_stats()
         answer = synthesize_city_ranking_answer(
             rows,
@@ -1924,7 +2114,7 @@ def handle_chat_query(question):
         }
 
     comparison_locations = extract_comparison_locations(question)
-    if comparison_locations and is_city_comparison_query(question):
+    if intent == "location_comparison" and comparison_locations:
         first_location, second_location = comparison_locations
         first_geo, first_label, first_buildings = resolve_location_buildings(first_location)
         second_geo, second_label, second_buildings = resolve_location_buildings(second_location)
@@ -1945,7 +2135,7 @@ def handle_chat_query(question):
         }
 
     percentage_location_text = extract_percentage_location_text(question)
-    if percentage_location_text:
+    if intent == "location_percentage" and percentage_location_text:
         _, damage_type = parse_question(question)
         geo, label_text, all_buildings = resolve_location_buildings(percentage_location_text)
         matching_buildings = filter_buildings_by_damage(all_buildings, damage_type)
@@ -1965,7 +2155,7 @@ def handle_chat_query(question):
         }
 
     general_location_text = extract_general_location_text(question)
-    if general_location_text:
+    if intent == "general_location_overview" and general_location_text:
         geo, label_text, all_buildings = resolve_location_buildings(general_location_text)
 
         if len(all_buildings) == 0:
@@ -1991,8 +2181,7 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    # block non-disaster queries
-    if not is_disaster_related(question):
+    if intent == "unsupported":
         answer = "I can only answer disaster-related queries about damage, safety, and assessments."
         save_turn(question, answer)
         return {
@@ -2003,9 +2192,8 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
             
-
     # full dataset summary does not have a single map focus
-    if is_full_dataset_query(question):
+    if intent == "full_dataset_summary":
         counts = get_full_dataset_damage_counts()
         answer = synthesize_location_overview_answer("the full dataset", counts)
         save_turn(question, answer)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -1,0 +1,916 @@
+# importing libraries needed for database, API calls, and environment variables
+import psycopg  # used to connect to PostgreSQL (Supabase)
+import requests  # used to make HTTP API calls (Mapbox + Nemotron)
+import os  # used to access environment variables
+import json  # used to convert GeoJSON text from PostGIS into a real Python dictionary
+from urllib.parse import quote  # used to safely encode values inside frontend route URLs
+from dotenv import load_dotenv  # used to load .env file
+
+# importing llamaindex components for LLM integration
+from llama_index.core import Settings
+from llama_index.core.llms import CustomLLM, CompletionResponse
+
+
+
+# storing conversation history for context
+chat_history = []
+
+# storing conversation history for context
+def save_turn(question, answer):
+    chat_history.append({"role": "user", "content": question})
+    chat_history.append({"role": "assistant", "content": answer})
+
+# loading environment variables from backend/.env file so secrets are not hardcoded
+load_dotenv("backend/.env", override=True)
+
+
+# default disaster name used when building frontend map routes
+# frontend route example: /map/hurricane-harvey/3?building=<building_uid>
+# this can be changed later through backend/.env if needed
+DEFAULT_DISASTER_NAME = os.getenv("DEFAULT_DISASTER_NAME", "hurricane-harvey")
+
+
+# function to connect to database using environment variables
+def get_db_connection():
+    return psycopg.connect(
+        host=os.getenv("DB_HOST"),  # database host from Supabase
+        port=os.getenv("DB_PORT", "5432"),  # default postgres port
+        dbname=os.getenv("DB_NAME", "postgres"),  # database name
+        user=os.getenv("DB_USER"),  # database user
+        password=os.getenv("DB_PASSWORD"),  # database password
+    )
+
+
+
+
+# function to convert SQL rows into Python dictionary format
+# this format is easier for the chatbot and frontend to use
+def rows_to_buildings(rows):
+    buildings = []  # list that will store all building dictionaries
+
+    for r in rows:
+        building_uid = str(r[0])  # convert UUID to string so frontend/JSON can use it
+        xbd_id = r[1]  # xBD image pair/scene id used in the frontend route
+        damage = r[2]  # predicted damage label from the database
+        geometry = r[3]  # building polygon geometry from PostGIS as GeoJSON text
+
+        # ST_AsGeoJSON returns geometry as a string, so convert it into a real JSON object
+        # this makes it easier for Mapbox/frontend to draw the polygon
+        if isinstance(geometry, str):
+            geometry = json.loads(geometry)
+
+        buildings.append({
+            "id": building_uid,  # keep id for general backend/frontend use
+            "uid": building_uid,  # exact field frontend uses for building route
+            "xbd_id": xbd_id,  # image pair id used in /map/:disasterName/:xbd_id
+            "damage": damage,  # damage level used for filtering/color-coding
+            "geometry": geometry  # GeoJSON polygon object for Mapbox
+        })
+
+    return buildings
+
+
+
+
+
+# function to parse user question (very simple NLP logic for MVP)
+def parse_question(question):
+
+    q = question.lower()
+
+    # detect damage type
+    if any(word in q for word in [ "fine", "no damage", "no-damage", "no damaged", "undamaged", "okay", "ok", "good", "unaffected"
+]):
+        damage = "no-damage"
+    elif "minor" in q:
+        damage = "minor-damage"
+    elif "destroyed" in q:
+        damage = "destroyed"
+    else:
+        damage = "major-damage"
+
+    # extract location if "near" exists
+    if "near" in q:
+        parts = q.split("near")
+        if len(parts) > 1:
+            address = parts[1].replace("?", "").strip()
+
+            for word in ["damage", "buildings", "area"]:
+                address = address.replace(word, "").strip()
+
+            # fix vague location like "me"
+            if address in ["me", "here", "my", "", "?"]:
+                address = "Houston Texas"
+        else:
+            address = "Houston Texas"
+
+    else:
+        address = None
+
+        # try to get location from chat history
+        for msg in reversed(chat_history):
+            content = msg.get("content", "").lower()
+
+            if "houston" in content:
+                address = "Houston Texas"
+                break
+
+        # final fallback
+        if not address:
+            address = "Houston Texas"
+
+    return address, damage
+
+
+
+
+# function to convert address → latitude/longitude using Mapbox API
+def geocode_address(address):
+
+    api_key = os.getenv("MAPBOX_API_KEY")  # getting API key
+
+    # building Mapbox API URL
+    url = f"https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json"
+
+    params = {
+        "access_token": api_key,
+        "limit": 1  # only need top result
+    }
+
+    # sending request to Mapbox
+    response = requests.get(url, params=params)
+
+    # if API fails, return None
+    if response.status_code != 200:
+        return None
+
+    data = response.json()
+
+    # if no results found
+    if len(data["features"]) == 0:
+        return None
+
+    coords = data["features"][0]["center"]
+
+    return {
+        "lon": coords[0],  # longitude
+        "lat": coords[1],  # latitude
+        "formatted_address": data["features"][0]["place_name"]  # clean address
+    }
+
+
+
+
+# this function checks if the user is asking a "decision-type" question
+# like safety, travel, repairs, rebuilding etc basically detecting advisory intent using simple keyword matching
+def detect_advisory(question):
+
+    q = question.lower() # converting to lowercase so matching is easier
+
+    # checking if user is asking about safety
+    if "safe" in q:
+        return "safety"
+
+     # checking if user is asking about travel conditions
+    if "travel" in q:
+        return "travel"
+
+     # checking if user is asking about repair or fixing buildings
+    if "repair" in q or "fix" in q:
+        return "repair"
+
+    # checking if user is asking about rebuilding / reconstruction
+    if "rebuild" in q or "reconstruct" in q:
+        return "rebuild"
+
+    #if none then it is not an advisory 
+    return None
+
+
+
+# this function generates a smart response using LLM
+# it combines actual building damage data with general reasoning so it acts like a "decision-support" layer, not just raw data output
+def advisory_response(question, buildings, address):
+
+    # creating a dictionary to count how many buildings per damage type
+    counts = {}
+
+    for b in buildings:
+        d = b["damage"] # getting damage label
+        counts[d] = counts.get(d, 0) + 1
+
+    # building a prompt for the LLM
+    # we pass structured data + user question so model can reason
+    prompt = f"""
+You are a disaster assessment assistant.
+
+Location: {address}
+Damage breakdown: {counts}
+User question: {question}
+
+Give a short, realistic answer.
+
+- Do NOT say "assistant"
+- Do NOT refer to yourself
+- Speak directly
+- Use cautious reasoning (e.g., "based on damage levels", "may require")
+
+Keep it 1–2 sentences.
+
+
+
+"""
+     # calling Nemotron LLM to generate final answer
+    return call_nemotron(prompt)
+
+
+
+
+# function to query buildings near a location using PostGIS
+def get_buildings_near(lon, lat, radius_m, damage_filter):
+
+    conn = get_db_connection()  # connecting to database
+    cur = conn.cursor()  # creating a cursor so we can run SQL queries
+
+    # SQL query using spatial filtering with ST_DWithin
+    # b.uid is the building UID used by the frontend route
+    # ip.xbd_id is the xBD image pair id used by the frontend route
+    # b.predicted_damage is the stored damage label
+    # ST_AsGeoJSON converts the building polygon into GeoJSON text
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE ST_DWithin(
+        b.geom::geography,
+        ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
+        %s
+    )
+    AND b.predicted_damage = %s
+    """
+
+    # executing query safely using parameters
+    cur.execute(query, (lon, lat, radius_m, damage_filter))
+
+    rows = cur.fetchall()  # getting all matching building rows
+
+    cur.close()  # closing cursor
+    conn.close()  # closing database connection
+
+    return rows_to_buildings(rows)  # converting SQL rows into dictionaries
+
+
+
+
+# function to query all buildings near a location, without filtering by damage type
+# this is used for summaries and advisory questions because those need all damage levels
+def get_all_buildings_near(lon, lat, radius_m):
+    conn = get_db_connection()  # connecting to database
+    cur = conn.cursor()  # creating cursor to run SQL
+
+    # SQL query using spatial filtering only
+    # b.uid is the building UID used by the frontend route
+    # ip.xbd_id is the xBD image pair id used by the frontend route
+    # b.predicted_damage is used for summaries and color-coding
+    # ST_AsGeoJSON converts the building polygon into GeoJSON text
+    query = """
+    SELECT b.uid, ip.xbd_id, b.predicted_damage, ST_AsGeoJSON(b.geom)
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    WHERE ST_DWithin(
+        b.geom::geography,
+        ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
+        %s
+    )
+    """
+
+    cur.execute(query, (lon, lat, radius_m))  # safely passing lon, lat, and radius into SQL
+    rows = cur.fetchall()  # getting all matching nearby buildings
+
+    cur.close()  
+    conn.close()  # closing database connection
+
+    return rows_to_buildings(rows)  # converting SQL rows into frontend-friendly dictionaries
+
+
+
+
+def get_full_dataset_damage_counts():
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT predicted_damage, COUNT(*)
+    FROM buildings
+    GROUP BY predicted_damage
+    """
+
+    cur.execute(query)
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    counts = {
+        "no-damage": 0,
+        "minor-damage": 0,
+        "major-damage": 0,
+        "destroyed": 0
+    }
+
+    for damage, count in rows:
+        counts[damage] = count
+
+    return counts
+
+
+def count_damage_levels(buildings):
+    counts = {
+        "no-damage": 0,
+        "minor-damage": 0,
+        "major-damage": 0,
+        "destroyed": 0
+    }
+
+    for b in buildings:
+        damage = b["damage"]
+        counts[damage] = counts.get(damage, 0) + 1
+
+    return counts
+
+
+def format_damage_count_response(counts, location_text):
+    total = sum(counts.values())
+
+    if total == 0:
+        return f"I couldn’t find damage assessment data for {location_text}."
+
+    known_total = (
+        counts.get("no-damage", 0)
+        + counts.get("minor-damage", 0)
+        + counts.get("major-damage", 0)
+        + counts.get("destroyed", 0)
+    )
+
+    other_total = total - known_total
+
+    response = (
+        f"For {location_text}, I found {total} buildings total: "
+        f"{counts.get('no-damage', 0)} no-damage, "
+        f"{counts.get('minor-damage', 0)} minor-damage, "
+        f"{counts.get('major-damage', 0)} major-damage, and "
+        f"{counts.get('destroyed', 0)} destroyed"
+    )
+
+    if other_total > 0:
+        response += f", with {other_total} other or unlabeled records"
+
+    return response + "."
+
+
+
+
+# function used when there is no frontend navigation action
+# this keeps the response format consistent for every chatbot answer
+def build_no_action():
+    return {
+        "type": "none",  # tells frontend there is no route to open
+        "target": None,  # no map/building/image-pair target
+        "reason": "no_navigation_target",  # explains why no action is included
+        "url": None,  # no URL for frontend to navigate to
+        "params": {}  # no route parameters
+    }
+
+
+# function to build the base frontend map route
+# frontend route format: /map/:disasterName/:xbd_id
+def build_map_route(disaster_name, xbd_id):
+    if not disaster_name or not xbd_id:
+        return None  # cannot build route if disaster name or xbd_id is missing
+
+    return f"/map/{quote(str(disaster_name))}/{quote(str(xbd_id))}"
+
+
+# function to build the frontend building route
+# frontend route format: /map/:disasterName/:xbd_id?building=:buildingUid
+def build_building_route(disaster_name, xbd_id, building_uid):
+    base_route = build_map_route(disaster_name, xbd_id)  # create base map route first
+
+    if not base_route or not building_uid:
+        return None  # cannot build building route if base route or building uid is missing
+
+    return f"{base_route}?building={quote(str(building_uid))}"
+
+
+# function to create a navigation action for map-level results
+# this is used when the chatbot finds multiple relevant buildings
+def build_map_action(geo, buildings):
+    xbd_ids = sorted({
+        b.get("xbd_id")  # collect xbd_id values from returned buildings
+        for b in buildings
+        if b.get("xbd_id") is not None  # ignore missing xbd_id values
+    })
+
+    primary_xbd_id = xbd_ids[0] if len(xbd_ids) == 1 else None  # only choose route if all buildings are from one xbd scene
+
+    return {
+        "type": "navigate",  # tells frontend this action should navigate somewhere
+        "target": "map",  # frontend should open/focus a map view
+        "reason": "location_or_damage_query",  # explains why this action exists
+        "url": build_map_route(DEFAULT_DISASTER_NAME, primary_xbd_id),  # route if one xbd_id is clear
+        "params": {
+            "disaster_name": DEFAULT_DISASTER_NAME,  # disaster name used by frontend route
+            "xbd_id": primary_xbd_id,  # xBD scene id, if one clear scene exists
+            "lat": geo["lat"],  # latitude for map focus
+            "lon": geo["lon"],  # longitude for map focus
+            "address": geo["formatted_address"],  # readable location name
+            "building_ids": [b["uid"] for b in buildings]  # matching building UIDs for highlighting
+        }
+    }
+
+
+# function to create a navigation action for one specific building
+# this is used when the chatbot result clearly identifies one building
+def build_building_action(building):
+    return {
+        "type": "navigate",  # tells frontend to navigate
+        "target": "building",  # frontend should open/focus a building view
+        "reason": "single_building_match",  # explains why this is building-level
+        "url": build_building_route(
+            DEFAULT_DISASTER_NAME,  # disaster name used by frontend route
+            building.get("xbd_id"),  # xBD scene id for this building
+            building.get("uid")  # building UID for the query parameter
+        ),
+        "params": {
+            "disaster_name": DEFAULT_DISASTER_NAME,  # disaster name for route
+            "xbd_id": building.get("xbd_id"),  # xBD scene id for route
+            "building_uid": building.get("uid"),  # building UID for route
+            "damage": building.get("damage")  # damage label for frontend context
+        }
+    }
+
+
+# FRONTEND MAP / ROUTING HANDOFF:
+# Frontend can use:
+#   answer/response -> chatbot text
+#   focus -> zoom or pan map
+#   highlighted_buildings -> draw/highlight building polygons
+#   action -> navigate to map/building route
+def build_map_payload(answer, geo, buildings, action=None):
+    return {
+        "answer": answer,  # chatbot answer text
+        "response": answer,  # duplicate key in case frontend expects "response"
+        "focus": {
+            "lat": geo["lat"],  # latitude for map focus
+            "lon": geo["lon"],  # longitude for map focus
+            "address": geo["formatted_address"]  # readable address/location
+        },
+        "highlighted_buildings": buildings,  # building objects for frontend highlighting
+        "action": action or build_no_action()  # navigation instruction for frontend
+    }
+
+
+# Testing purpose only
+def print_map_payload_preview(payload):
+    print("[Map Focus]")
+    print(f"Address: {payload['focus']['address']}")
+    print(f"Lat/Lon: {payload['focus']['lat']}, {payload['focus']['lon']}")
+    print(f"Buildings to highlight: {len(payload['highlighted_buildings'])}")
+
+    for b in payload["highlighted_buildings"][:5]:
+        print(f"  - Building ID: {b['id']}, Damage: {b['damage']}")
+
+# ///////////////////////// #
+
+
+
+
+# function to call NVIDIA Nemotron API
+def call_nemotron(prompt):
+
+    url = os.getenv("NEMOTRON_URL")  # API endpoint
+    api_key = os.getenv("NEMOTRON_API_KEY")  # API key
+
+    # checking if config exists
+    if not url or not api_key:
+        return "Nemotron not configured"
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json"
+    }
+
+    # send only the current prompt to Nemotron
+    # save_turn() already handles chatbot conversation history separately
+    messages = [
+        {"role": "user", "content": prompt}
+    ]
+
+    payload = {
+        "model": "mistralai/mistral-nemotron",
+        "messages": messages,
+        "max_tokens": 300
+    }
+
+    response = requests.post(url, headers=headers, json=payload)
+
+    if response.status_code != 200:
+        return f"Error: {response.text}"
+
+    data = response.json()
+
+    return data["choices"][0]["message"]["content"].strip('"')
+
+
+
+
+# creating custom LLM wrapper for llamaindex
+class NemotronLLM(CustomLLM):
+
+    @property
+    def metadata(self):
+        return {
+            "context_window": 4096,
+            "num_output": 256,
+            "model_name": "nemotron"
+        }
+
+    def complete(self, prompt, **kwargs):
+        result = call_nemotron(prompt)
+        return CompletionResponse(text=result)
+
+    def stream_complete(self, prompt, **kwargs):
+        yield CompletionResponse(text=self.complete(prompt).text)
+
+
+    
+
+# registering LLM inside llamaindex
+Settings.llm = NemotronLLM()
+
+
+
+
+# function to generate final AI answer using LLM
+def generate_llm_answer(buildings, address, damage_type):
+
+    total = len(buildings)
+    clean_damage = damage_type.replace("-", " ")
+
+    prompt = f"""
+You are Hazardly, a disaster damage assessment chatbot.
+
+Use the exact facts below:
+Location: {address}
+Damage type: {clean_damage}
+Number of buildings: {total}
+
+Write one short, clear sentence for the user.
+
+Rules:
+- Do NOT mention VLM, model, prediction data, database, SQL, backend, or LLM.
+- Do NOT change the number.
+- Do NOT add extra numbers.
+- Do NOT say the area is completely safe.
+- Sound professional and natural.
+"""
+
+    return str(Settings.llm.complete(prompt)).strip('"').split(")*")[0]
+
+
+def is_disaster_related(question):
+
+    q = question.lower()
+
+    keywords = [
+        # damage + building
+        "damage", "building", "structure", "collapse", "destruction", "minor", "major", "destroyed",
+
+        # disaster types
+        "disaster", "hurricane", "flood", "earthquake", "storm", "harvey", "natural disaster",
+
+        # safety + advisory
+        "safe", "danger", "risk", "travel", "evacuate", "return", "inspection",
+
+        # repair + recovery
+        "repair", "fix", "rebuild", "reconstruct", "recovery", "restoration", "infrastructure",
+
+        # data / queries
+        "how many", "count", "stats", "analysis", "impact", "dataset", "full dataset", "all buildings",
+
+        # location words
+        "near", "area", "region", "city", "street",
+
+        # image / VLM related
+        "image", "photo", "picture", "pre", "post", "before", "after", "compare", "upload", "evaluate"
+    ]
+
+    return any(k in q for k in keywords)
+
+
+def is_vlm_query(q):
+
+    q = q.lower()
+    return any(k in q for k in [
+        "image", "images", "photo", "picture", "upload image", "upload photo",
+        "compare images", "pre-disaster image", "post-disaster image",
+        "before image", "after image", "evaluate image" , "evaluate photo", "evaluate picture"
+    ])
+  
+
+def vlm_guidance_response():
+
+    return (
+        "To evaluate damage using images, please upload a pre-disaster and post-disaster image pair "
+        "in the VLM Evaluation page. The system will analyze the images and classify the damage level "
+        "(No Damage, Minor, Major, or Destroyed)."
+    )
+
+
+def is_data_summary_query(question):
+    q = question.lower()
+    return any(k in q for k in [
+        "summary of damage", "summarize damage", "how bad", "overall damage", "damage summary",
+        "summarize the situation", "overview of damage", "damage situation", "damage breakdown","damage levels"
+    ])
+
+
+def is_full_dataset_query(question):
+    q = question.lower()
+
+    return any(k in q for k in [
+        "full dataset",
+        "whole dataset",
+        "entire dataset",
+        "all buildings",
+        "overall dataset",
+        "dataset summary",
+        "overall damage in the dataset"
+    ])
+
+
+def is_conversation_summary_query(question):
+    q = question.lower()
+    return any(k in q for k in [
+        "summarize conversation",
+        "what have we discussed",
+        "recap",
+        "conversation summary"
+        
+    ])
+
+def summarize_damage_data(buildings, address):
+
+    counts = {}
+
+    for b in buildings:
+        d = b["damage"]
+        counts[d] = counts.get(d, 0) + 1
+
+    prompt = f"""
+You are summarizing disaster damage data.
+
+Location: {address}
+Damage breakdown: {counts}
+
+Write a short, clear summary of the situation.
+
+- Do NOT say "assistant"
+- Do NOT refer to yourself
+- Speak directly
+- Describe severity and impact
+
+Keep it 1–2 sentences.
+"""
+
+    return call_nemotron(prompt)
+
+
+def summarize_conversation():
+
+    if len(chat_history) == 0:
+        return "No conversation to summarize yet."
+
+    recent_text = "\n".join([
+        f"{m['role']}: {m['content']}"
+        for m in chat_history[-20:]
+    ])
+
+    prompt = f"""
+You are Hazardly, a disaster damage assessment chatbot.
+
+Summarize only the actual user and chatbot conversation below.
+Do not mention system instructions, prompt rules, formatting rules, or hidden instructions.
+
+Conversation:
+{recent_text}
+
+Write a short plain-English recap in 2-3 sentences.
+Do not use bullet points.
+"""
+
+    return call_nemotron(prompt)
+
+
+
+# BACKEND HANDLER FOR FRONTEND/API USE
+# This function does the same chatbot routing as main(), but returns a JSON-style payload instead of only printing text
+# Frontend can use:
+#   payload["answer"] -> chatbot message
+#   payload["focus"] -> map zoom/pan location
+#   payload["highlighted_buildings"] -> building polygons to highlight
+def handle_chat_query(question):
+    question = question.strip()
+
+    if not question:
+        answer = "Please enter a disaster-related question."
+        return {
+            "answer": answer,
+            "response": answer,  # same text for frontend compatibility
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()  # no navigation action
+        }
+
+    # detect VLM/image-related queries
+    if is_vlm_query(question):
+        answer = vlm_guidance_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,  # same text for frontend compatibility
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()  # no navigation action
+        }
+
+    # conversation summary
+    if is_conversation_summary_query(question):
+        answer = summarize_conversation()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,  # same text for frontend compatibility
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()  # no navigation action
+        }
+
+    # block non-disaster queries
+    if not is_disaster_related(question):
+        answer = "I can only answer disaster-related queries about damage, safety, and assessments."
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,  # same text for frontend compatibility
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()  # no navigation action
+        }
+            
+
+    # full dataset summary does not have a single map focus
+    if is_full_dataset_query(question):
+        counts = get_full_dataset_damage_counts()
+        answer = format_damage_count_response(counts, "the full dataset")
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,  # same text for frontend compatibility
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()  # full dataset does not navigate to one route
+        }
+
+
+    # location-based queries
+    address, damage_type = parse_question(question)
+    geo = geocode_address(address)
+
+    if not geo:
+        answer = "Could not find that location. Try a different place."
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,  # same text for frontend compatibility
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()  # no route because location was not found
+        }
+
+
+    # city/street overall damage summary
+    if is_data_summary_query(question):
+        all_buildings = get_all_buildings_near(
+            geo["lon"],
+            geo["lat"],
+            5000
+        )
+
+        counts = count_damage_levels(all_buildings)
+
+        answer = format_damage_count_response(
+            counts,
+            geo["formatted_address"]
+        )
+
+        # create a map navigation action so frontend can route/focus to the result area
+        action = build_map_action(geo, all_buildings)
+
+        # package chatbot answer, map focus, highlighted buildings, and navigation action
+        payload = build_map_payload(answer, geo, all_buildings, action)
+
+        save_turn(question, answer)
+        return payload
+
+    # advisory questions use all nearby damage levels
+    advisory = detect_advisory(question)
+
+    if advisory:
+        all_buildings = get_all_buildings_near(
+            geo["lon"],
+            geo["lat"],
+            5000
+        )
+
+        if len(all_buildings) == 0:
+            answer = "I couldn’t find enough nearby damage data to give a reliable advisory for that area."
+            action = build_no_action()
+        else:
+            answer = advisory_response(question, all_buildings, geo["formatted_address"])
+
+            # create a map navigation action because advisory answers still relate to this location
+            action = build_map_action(geo, all_buildings)
+
+        # package chatbot answer, map focus, highlighted buildings, and navigation action
+        payload = build_map_payload(answer, geo, all_buildings, action)
+
+
+        save_turn(question, answer)
+        return payload
+
+    # exact damage count questions use filtered buildings
+    buildings = get_buildings_near(
+        geo["lon"],
+        geo["lat"],
+        5000,
+        damage_type
+    )
+
+    if len(buildings) == 0:
+        answer = "I could not find relevant damage data for that area. Try a different location."
+        save_turn(question, answer)
+        return {
+            "answer": answer,  # chatbot response text
+            "response": answer,  # same text for frontend compatibility
+            "focus": {
+                "lat": geo["lat"],  # latitude of the searched location
+                "lon": geo["lon"],  # longitude of the searched location
+                "address": geo["formatted_address"]  # readable searched address
+            },
+            "highlighted_buildings": [],  # no buildings matched
+            "action": build_no_action()  # no navigation target because no building was found
+        }
+
+    if damage_type == "no-damage":
+        answer = f"{len(buildings)} buildings in {geo['formatted_address']} appear to have no visible damage."
+    else:
+        answer = generate_llm_answer(buildings, geo["formatted_address"], damage_type)
+
+    # if only one building matched, frontend can route directly to that building
+    if len(buildings) == 1:
+        action = build_building_action(buildings[0])
+
+    # if multiple buildings matched, frontend should route/focus to the map view
+    else:
+        action = build_map_action(geo, buildings)
+
+    # package chatbot answer, map focus, highlighted buildings, and navigation action
+    payload = build_map_payload(answer, geo, buildings, action)
+    save_turn(question, answer)
+    return payload
+
+
+
+# MAIN FUNCTION (entry point of program)
+def main():
+
+    while True:
+
+        user_input = input("User: ")
+
+        if user_input.lower() in ["exit", "quit", "bye", "goodbye"]:
+            print("\nHazardly: Goodbye! Stay safe.")
+            break
+
+        questions = [q.strip() for q in user_input.split("\n") if q.strip()]
+
+        for question in questions:
+            payload = handle_chat_query(question)
+            answer = payload["answer"]
+
+            print(f"\nHazardly: {answer}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -23,6 +23,29 @@ def save_turn(question, answer):
     chat_history.append({"role": "user", "content": question})
     chat_history.append({"role": "assistant", "content": answer})
 
+
+def get_last_user_message():
+    for message in reversed(chat_history):
+        if message.get("role") == "user":
+            return message.get("content", "")
+    return ""
+
+
+def get_last_assistant_message():
+    for message in reversed(chat_history):
+        if message.get("role") == "assistant":
+            return message.get("content", "")
+    return ""
+
+
+def is_dataset_scope_followup(question):
+    normalized_question = question.strip().lower()
+    if normalized_question not in {"full", "full dataset", "dataset", "all"}:
+        return False
+
+    last_assistant_message = get_last_assistant_message().lower()
+    return "full dataset, or for a specific city or area" in last_assistant_message
+
 # loading environment variables from backend/.env file so secrets are not hardcoded
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BACKEND_DIR / ".env", override=True)
@@ -727,7 +750,8 @@ def format_city_ranking(rows, metric, limit):
     if len(rows) == 0:
         return "I couldn't find any city-level data for the active disaster dataset."
 
-    sorted_rows = sort_city_rows(rows, metric)[:limit]
+    sorted_rows = sort_city_rows(rows, metric)
+    limited_rows = sorted_rows[:limit]
     metric_label = {
         "total": "total buildings",
         "no-damage": "undamaged buildings",
@@ -736,8 +760,14 @@ def format_city_ranking(rows, metric, limit):
         "destroyed": "destroyed buildings",
     }[metric]
 
-    lines = [f"Top cities by {metric_label}:"]
-    for row in sorted_rows:
+    header = (
+        f"Cities in the dataset by {metric_label}:"
+        if limit >= len(sorted_rows)
+        else f"Top cities by {metric_label}:"
+    )
+
+    lines = [header]
+    for row in limited_rows:
         city = row[0]
         value = row[{ "total": 1, "no-damage": 2, "minor-damage": 3, "major-damage": 4, "destroyed": 5 }[metric]]
         total = row[1]
@@ -1834,6 +1864,15 @@ Label:
 
 
 def classify_query_intent(question):
+    normalized_question = question.strip().lower()
+    if is_dataset_scope_followup(question):
+        last_user_message = get_last_user_message().lower()
+        if any(term in last_user_message for term in ["show", "open", "take me", "go to"]):
+            inherited_damage_filter = extract_damage_filter(last_user_message)
+            if inherited_damage_filter or "building" in last_user_message:
+                return "location_query"
+            return "full_dataset_summary"
+
     heuristic_intent = classify_query_intent_heuristic(question)
     if heuristic_intent:
         return heuristic_intent
@@ -1911,6 +1950,13 @@ def parse_structured_query(question):
     }.get(raw_intent, raw_intent)
 
     explicit_scene_id = extract_xbd_query_id(question)
+    dataset_scope_followup = is_dataset_scope_followup(question)
+    inherited_user_message = get_last_user_message() if dataset_scope_followup else ""
+    inherited_damage_filter = (
+        extract_damage_filter(inherited_user_message)
+        if dataset_scope_followup
+        else None
+    )
     comparison_locations = extract_comparison_locations(question)
     percentage_location_text = extract_percentage_location_text(question)
     general_location_text = extract_general_location_text(question)
@@ -1926,12 +1972,19 @@ def parse_structured_query(question):
         else None
     )
     parsed_address, parsed_default_damage = parse_question(question)
+    explicit_near_or_in_match = re.search(
+        r"\b(?:near|in)\s+(.+?)(?:\?|$)",
+        question,
+        flags=re.IGNORECASE,
+    )
 
     locations = []
     query_mode = "generic_location"
     primary_location = None
 
-    if mapped_intent == "location_comparison" and comparison_locations:
+    if dataset_scope_followup and mapped_intent == "location_query":
+        query_mode = "dataset_scope_followup"
+    elif mapped_intent == "location_comparison" and comparison_locations:
         first_location = normalize_location_candidate(comparison_locations[0])
         second_location = normalize_location_candidate(comparison_locations[1])
         locations = [location for location in [first_location, second_location] if location]
@@ -1962,10 +2015,16 @@ def parse_structured_query(question):
         locations = [primary_location]
         query_mode = "scene"
     else:
-        primary_location = normalize_location_candidate(parsed_address)
+        primary_location = (
+            normalize_location_candidate(parsed_address)
+            if explicit_near_or_in_match
+            else None
+        )
         locations = [primary_location] if primary_location else []
 
     damage_filter = extract_damage_filter(question)
+    if damage_filter is None and inherited_damage_filter is not None:
+        damage_filter = inherited_damage_filter
     if mapped_intent == "location_query" and damage_filter is None:
         damage_filter = parsed_default_damage
     if mapped_intent in {"location_overview", "dataset_overview", "city_list", "city_count"}:
@@ -1975,6 +2034,8 @@ def parse_structured_query(question):
         phrase in question.lower()
         for phrase in ["show ", "show me", "take me", "open ", "go to ", "navigate"]
     )
+    if dataset_scope_followup and query_mode == "dataset_scope_followup":
+        wants_navigation = False
     wants_summary = mapped_intent in {
         "dataset_overview",
         "location_overview",
@@ -2002,7 +2063,11 @@ def parse_structured_query(question):
         "entity_type": entity_type,
         "explicit_scene_id": explicit_scene_id,
         "wants_summary": wants_summary,
-        "wants_all_buildings": is_all_buildings_query(question),
+        "wants_all_buildings": (
+            inherited_damage_filter is None
+            if dataset_scope_followup and query_mode == "dataset_scope_followup"
+            else is_all_buildings_query(question)
+        ),
         "advisory": detect_advisory(question),
         "query_mode": query_mode,
         "primary_location": primary_location,
@@ -2354,6 +2419,19 @@ def handle_chat_query(question):
             "action": build_no_action()  # full dataset does not navigate to one route
         }
 
+    if intent == "location_query" and parsed_query["query_mode"] == "dataset_scope_followup":
+        rows = fetch_city_damage_stats(limit=500)
+        metric = damage_type if not wants_all_buildings else "total"
+        answer = format_city_ranking(rows, metric, len(rows))
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
     if intent == "scene_query" and xbd_query_id is not None:
         requested_damage = None if wants_all_buildings else damage_type
         buildings = get_buildings_for_xbd(xbd_query_id, requested_damage)
@@ -2543,7 +2621,12 @@ def handle_chat_query(question):
     # generic location-based queries
     address = primary_location
     if not address:
-        answer = "I could not determine which location or scene you meant."
+        if intent == "location_query" and parsed_query["needs_map"]:
+            answer = (
+                "Do you want those results for the full dataset, or for a specific city or area?"
+            )
+        else:
+            answer = "I could not determine which location or scene you meant."
         save_turn(question, answer)
         return {
             "answer": answer,

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -245,6 +245,7 @@ def extract_general_location_text(question):
     patterns = [
         r"tell me about\s+(.+?)(?:\?|$)",
         r"what about\s+(.+?)(?:\?|$)",
+        r"what happened\s+(?:to|in|near|around)\s+(.+?)(?:\?|$)",
         r"give me stats for\s+(.+?)(?:\?|$)",
         r"give me information about\s+(.+?)(?:\?|$)",
         r"overview of\s+(.+?)(?:\?|$)",
@@ -2091,10 +2092,157 @@ def is_damage_label_query(question):
     ])
 
 
+def is_help_query(question):
+    normalized_question = re.sub(r"\s+", " ", question.strip().lower()).strip(" ?.")
+    return normalized_question in {
+        "help",
+        "what can you do",
+        "what can you help with",
+        "what do you do",
+        "how can you help",
+        "how can you help me",
+        "what should i ask",
+        "what questions can i ask",
+        "what can i ask",
+    }
+
+
+def is_greeting_query(question):
+    normalized_question = re.sub(r"\s+", " ", question.strip().lower()).strip(" !?.")
+    return normalized_question in {
+        "hi",
+        "hello",
+        "hey",
+        "good morning",
+        "good afternoon",
+        "good evening",
+    }
+
+
+def is_identity_query(question):
+    normalized_question = re.sub(r"\s+", " ", question.strip().lower()).strip(" !?.")
+    return normalized_question in {
+        "who are you",
+        "what are you",
+        "what is your name",
+        "what's your name",
+        "who am i talking to",
+        "are you hazardly",
+    }
+
+
+def is_acknowledgement_query(question):
+    normalized_question = re.sub(r"\s+", " ", question.strip().lower()).strip(" !?.")
+    acknowledgement_phrases = {
+        "thanks",
+        "thank you",
+        "thank u",
+        "thx",
+        "appreciate it",
+        "i appreciate it",
+        "got it",
+        "ok",
+        "okay",
+        "sounds good",
+    }
+    return normalized_question in acknowledgement_phrases and bool(get_last_assistant_message())
+
+
+def greeting_response():
+    return (
+        "Hi, I am Hazardly. Ask me about disaster damage counts, affected cities, damaged buildings near a "
+        "location, xBD scenes, or safety and repair guidance from the active dataset."
+    )
+
+
+def identity_response():
+    return (
+        "I am Hazardly, a disaster damage assessment assistant for the active dataset. I can help with damage "
+        "counts, affected cities, damaged buildings near a location, xBD scenes, and safety or repair guidance."
+    )
+
+
+def acknowledgement_response():
+    return "You're welcome. Ask me if you want to look at another location, scene, or damage level."
+
+
+def help_response():
+    return "\n".join([
+        "I can help with disaster damage assessment questions for the active dataset.",
+        "Try asking for a dataset summary, affected cities, damage counts, damaged buildings near a city or address, a specific xBD scene, misclassified buildings, or safety/repair guidance based on nearby damage levels.",
+        "Examples: \"Show destroyed buildings near Houston\", \"Summarize damage in Sugar Land\", or \"What cities have the most major damage?\"",
+    ])
+
+
+def ambiguous_query_response(parsed_query):
+    if parsed_query["intent"] in {"location_query", "location_overview"}:
+        return (
+            "I need a little more detail to answer that. Please include a city, area, address, xBD scene, "
+            "or say \"full dataset\" if you want overall results. For example: \"Show major damage near Houston\" "
+            "or \"Summarize the full dataset.\""
+        )
+
+    return (
+        "I am not sure which damage assessment question you want answered. You can ask about the full dataset, "
+        "affected cities, damage levels, a city or address, an xBD scene, or safety and repair guidance."
+    )
+
+
+def unsupported_query_response():
+    return (
+        "I understand this is related to disaster damage assessment, but I have not been taught how to answer that "
+        "kind of request yet. Try asking about damage counts, affected cities, damaged buildings near a location, "
+        "xBD scenes, or safety and repair guidance from the active dataset."
+    )
+
+
+def out_of_scope_query_response():
+    return (
+        "That is outside my disaster damage assessment scope. I can help with damage counts, affected cities, "
+        "damaged buildings near a location, xBD scenes, or safety and repair guidance from the active dataset."
+    )
+
+
+def is_untrained_disaster_request(question):
+    q = question.lower()
+    unsupported_terms = [
+        "forecast",
+        "predict",
+        "tomorrow",
+        "next week",
+        "future",
+        "live",
+        "real-time",
+        "realtime",
+        "insurance",
+        "claim",
+        "fema",
+        "permit",
+        "lawsuit",
+        "legal",
+    ]
+    return is_disaster_related(question) and any(term in q for term in unsupported_terms)
+
+
 def classify_query_intent_heuristic(question):
     lowered_question = question.lower()
 
     if is_scope_clarification_prompt(question):
+        return "unsupported"
+
+    if is_greeting_query(question):
+        return "greeting"
+
+    if is_identity_query(question):
+        return "identity"
+
+    if is_acknowledgement_query(question):
+        return "acknowledgement"
+
+    if is_help_query(question):
+        return "help"
+
+    if is_untrained_disaster_request(question):
         return "unsupported"
 
     if is_vlm_query(question):
@@ -2179,6 +2327,10 @@ Choose exactly one label from this list:
 - city_count
 - damage_labels
 - city_ranking
+- greeting
+- identity
+- acknowledgement
+- help
 - location_comparison
 - location_percentage
 - conversation_summary
@@ -2187,6 +2339,7 @@ Choose exactly one label from this list:
 - general_location_overview
 - location_query
 - unsupported
+- out_of_scope
 
 Definitions:
 - full_dataset_summary: asks about the dataset as a whole, what the data contains, or overall damage across the dataset, without focusing on one place
@@ -2197,6 +2350,10 @@ Definitions:
 - city_count: asks how many cities or locations are represented
 - damage_labels: asks which damage labels or levels exist
 - city_ranking: asks which cities have the most or least damage
+- greeting: brief conversational opener such as hello, hi, or hey
+- identity: asks who the assistant is or what it does
+- acknowledgement: brief thanks or acknowledgement after the assistant has answered
+- help: asks what the assistant can do or what questions are supported
 - location_comparison: compares two named locations
 - location_percentage: asks what percentage/share of buildings in a place fit a damage level
 - conversation_summary: asks for a recap of the conversation
@@ -2204,7 +2361,8 @@ Definitions:
 - xbd_query: directly references an xBD scene ID
 - general_location_overview: asks for an overview or summary of damage in one place
 - location_query: asks about buildings or damage for one place, address, area, or scene, including map-like requests
-- unsupported: not related to disaster damage assessment
+- unsupported: related to disaster damage assessment, but not a supported capability
+- out_of_scope: not related to disaster damage assessment
 
 Examples:
 Question: Tell me about the data
@@ -2215,6 +2373,9 @@ Label: full_dataset_summary
 
 Question: What cities are in the dataset?
 Label: city_list
+
+Question: What can you help with?
+Label: help
 
 Question: Compare Houston and Sugar Land
 Label: location_comparison
@@ -2258,6 +2419,10 @@ Label:
         "city_count",
         "damage_labels",
         "city_ranking",
+        "greeting",
+        "identity",
+        "acknowledgement",
+        "help",
         "location_comparison",
         "location_percentage",
         "conversation_summary",
@@ -2266,6 +2431,7 @@ Label:
         "general_location_overview",
         "location_query",
         "unsupported",
+        "out_of_scope",
     }
 
     return label if label in valid_labels else None
@@ -2297,7 +2463,7 @@ def classify_query_intent(question):
     if is_disaster_related(question):
         return "location_query"
 
-    return "unsupported"
+    return "out_of_scope"
 
 
 def extract_damage_filter(question):
@@ -2369,8 +2535,12 @@ def parse_structured_query(question):
         "misclassified_buildings": "misclassified_buildings",
         "city_list": "city_list",
         "city_count": "city_count",
-        "damage_labels": "damage_label_query",
+        "damage_labels": "damage_labels",
         "city_ranking": "city_ranking",
+        "greeting": "greeting",
+        "identity": "identity",
+        "acknowledgement": "acknowledgement",
+        "help": "help",
         "location_comparison": "location_comparison",
         "location_percentage": "location_percentage",
         "conversation_summary": "conversation_summary",
@@ -2379,6 +2549,7 @@ def parse_structured_query(question):
         "general_location_overview": "location_overview",
         "location_query": "location_query",
         "unsupported": "unsupported",
+        "out_of_scope": "out_of_scope",
     }.get(raw_intent, raw_intent)
 
     explicit_scene_id = extract_xbd_query_id(question)
@@ -2488,7 +2659,11 @@ def parse_structured_query(question):
         "location_percentage",
         "city_list",
         "city_count",
-        "damage_label_query",
+        "damage_labels",
+        "greeting",
+        "identity",
+        "acknowledgement",
+        "help",
         "conversation_summary",
         "scene_count",
         "scene_ranking",
@@ -2695,6 +2870,50 @@ def handle_chat_query(question):
     primary_location = parsed_query["primary_location"]
     advisory = parsed_query["advisory"]
     xbd_query_id = parsed_query["explicit_scene_id"]
+
+    if intent == "greeting":
+        answer = greeting_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()
+        }
+
+    if intent == "identity":
+        answer = identity_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()
+        }
+
+    if intent == "acknowledgement":
+        answer = acknowledgement_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()
+        }
+
+    if intent == "help":
+        answer = help_response()
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action()
+        }
 
     if intent == "vlm_query":
         answer = vlm_guidance_response()
@@ -2951,11 +3170,13 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    if intent == "unsupported":
+    if intent in {"unsupported", "out_of_scope"}:
         if is_scope_clarification_prompt(question):
             answer = "Please answer with either the full dataset or a specific city or area."
+        elif intent == "out_of_scope":
+            answer = out_of_scope_query_response()
         else:
-            answer = "I can only answer disaster-related queries about damage, safety, and assessments."
+            answer = unsupported_query_response()
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -3192,15 +3413,7 @@ def handle_chat_query(question):
     # generic location-based queries
     address = primary_location
     if not address:
-        if (
-            (intent == "location_query" and (parsed_query["needs_map"] or parsed_query["damage_filter"]))
-            or (intent == "location_overview" and parsed_query["damage_filter"] and not primary_location)
-        ):
-            answer = (
-                "Do you want those results for the full dataset, or for a specific city or area?"
-            )
-        else:
-            answer = "I could not determine which location or scene you meant."
+        answer = ambiguous_query_response(parsed_query)
         save_turn(question, answer)
         return {
             "answer": answer,

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -699,7 +699,15 @@ def get_ranking_metric(question):
         return "major-damage"
     if "minor" in q:
         return "minor-damage"
-    if any(term in q for term in ["no damage", "no-damage", "undamaged", "least damage"]):
+    if any(term in q for term in [
+        "no damage",
+        "no-damage",
+        "undamaged",
+        "non-damaged",
+        "non damaged",
+        "not damaged",
+        "least damage",
+    ]):
         return "no-damage"
     return "total"
 
@@ -722,9 +730,9 @@ def format_city_ranking(rows, metric, limit):
     sorted_rows = sort_city_rows(rows, metric)[:limit]
     metric_label = {
         "total": "total buildings",
-        "no-damage": "no-damage buildings",
-        "minor-damage": "minor-damage buildings",
-        "major-damage": "major-damage buildings",
+        "no-damage": "undamaged buildings",
+        "minor-damage": "minorly damaged buildings",
+        "major-damage": "majorly damaged buildings",
         "destroyed": "destroyed buildings",
     }[metric]
 
@@ -739,30 +747,7 @@ def format_city_ranking(rows, metric, limit):
 
 
 def synthesize_city_ranking_answer(rows, metric, limit):
-    fallback = format_city_ranking(rows, metric, limit)
-    metric_label = {
-        "total": "total buildings",
-        "no-damage": "no-damage buildings",
-        "minor-damage": "minor-damage buildings",
-        "major-damage": "major-damage buildings",
-        "destroyed": "destroyed buildings",
-    }[metric]
-    prompt = f"""
-You are Hazardly, a disaster damage assessment assistant.
-
-Use only these exact facts:
-Ranking metric: {metric_label}
-Top rows: {sort_city_rows(rows, metric)[:limit]}
-
-Write a concise answer for the user.
-
-Rules:
-- Use 3 to 5 short bullet points.
-- Keep the city names and numbers exact.
-- Mention which metric is being ranked.
-- Do not invent extra numbers or places.
-"""
-    return synthesize_structured_answer(prompt, fallback)
+    return format_city_ranking(rows, metric, limit)
 
 
 def format_percentage_response(location_text, damage_type, total, matching_total):
@@ -1863,6 +1848,168 @@ def classify_query_intent(question):
     return "unsupported"
 
 
+def extract_damage_filter(question):
+    q = question.lower()
+    if any(word in q for word in [
+        "fine", "no damage", "no-damage", "no damaged", "undamaged", "unaffected"
+    ]):
+        return "no-damage"
+    if "minor" in q:
+        return "minor-damage"
+    if "destroyed" in q:
+        return "destroyed"
+    if "major" in q or "damaged" in q or "damage" in q:
+        return "major-damage"
+    return None
+
+
+def normalize_location_candidate(location_text):
+    if not location_text:
+        return None
+
+    normalized = location_text.strip(" ?,.")
+    normalized = re.sub(
+        r"^(?:the\s+)?cities?\s+of\s+",
+        "",
+        normalized,
+        flags=re.IGNORECASE,
+    ).strip(" ,")
+    normalized = re.sub(r"\s+", " ", normalized).strip(" ,")
+    return normalized or None
+
+
+def infer_scope(location_text, explicit_scene_id=None):
+    if explicit_scene_id is not None:
+        return "scene"
+    if not location_text:
+        return "dataset"
+    if looks_like_exact_address(location_text):
+        return "address"
+    if looks_like_street_address(location_text):
+        return "street"
+    if "," in location_text:
+        return "area"
+    return "city"
+
+
+def parse_structured_query(question):
+    raw_intent = classify_query_intent(question)
+    mapped_intent = {
+        "full_dataset_summary": "dataset_overview",
+        "city_list": "city_list",
+        "city_count": "city_count",
+        "damage_labels": "damage_label_query",
+        "city_ranking": "city_ranking",
+        "location_comparison": "location_comparison",
+        "location_percentage": "location_percentage",
+        "conversation_summary": "conversation_summary",
+        "vlm": "vlm_query",
+        "xbd_query": "scene_query",
+        "general_location_overview": "location_overview",
+        "location_query": "location_query",
+        "unsupported": "unsupported",
+    }.get(raw_intent, raw_intent)
+
+    explicit_scene_id = extract_xbd_query_id(question)
+    comparison_locations = extract_comparison_locations(question)
+    percentage_location_text = extract_percentage_location_text(question)
+    general_location_text = extract_general_location_text(question)
+    on_location_text = (
+        extract_on_location_text(question)
+        if "near" not in question.lower()
+        else None
+    )
+    address_filter_text = extract_address_filter_text(question)
+    in_location_text = (
+        extract_in_location_text(question)
+        if "near" not in question.lower()
+        else None
+    )
+    parsed_address, parsed_default_damage = parse_question(question)
+
+    locations = []
+    query_mode = "generic_location"
+    primary_location = None
+
+    if mapped_intent == "location_comparison" and comparison_locations:
+        first_location = normalize_location_candidate(comparison_locations[0])
+        second_location = normalize_location_candidate(comparison_locations[1])
+        locations = [location for location in [first_location, second_location] if location]
+        primary_location = locations[0] if locations else None
+        query_mode = "comparison"
+    elif mapped_intent == "location_percentage" and percentage_location_text:
+        primary_location = normalize_location_candidate(percentage_location_text)
+        locations = [primary_location] if primary_location else []
+        query_mode = "percentage"
+    elif mapped_intent == "location_overview" and general_location_text:
+        primary_location = normalize_location_candidate(general_location_text)
+        locations = [primary_location] if primary_location else []
+        query_mode = "overview"
+    elif on_location_text:
+        primary_location = normalize_location_candidate(on_location_text)
+        locations = [primary_location] if primary_location else []
+        query_mode = "on_address"
+    elif address_filter_text:
+        primary_location = normalize_location_candidate(address_filter_text)
+        locations = [primary_location] if primary_location else []
+        query_mode = "address_filter"
+    elif in_location_text:
+        primary_location = normalize_location_candidate(in_location_text)
+        locations = [primary_location] if primary_location else []
+        query_mode = "in_location"
+    elif explicit_scene_id is not None:
+        primary_location = f"XBD {explicit_scene_id}"
+        locations = [primary_location]
+        query_mode = "scene"
+    else:
+        primary_location = normalize_location_candidate(parsed_address)
+        locations = [primary_location] if primary_location else []
+
+    damage_filter = extract_damage_filter(question)
+    if mapped_intent == "location_query" and damage_filter is None:
+        damage_filter = parsed_default_damage
+    if mapped_intent in {"location_overview", "dataset_overview", "city_list", "city_count"}:
+        damage_filter = None
+
+    wants_navigation = any(
+        phrase in question.lower()
+        for phrase in ["show ", "show me", "take me", "open ", "go to ", "navigate"]
+    )
+    wants_summary = mapped_intent in {
+        "dataset_overview",
+        "location_overview",
+        "location_comparison",
+        "location_percentage",
+        "city_list",
+        "city_count",
+        "damage_label_query",
+        "conversation_summary",
+    }
+
+    entity_type = "place"
+    if explicit_scene_id is not None:
+        entity_type = "scene"
+    elif query_mode in {"on_address", "address_filter", "in_location"}:
+        entity_type = "address"
+
+    return {
+        "intent": mapped_intent,
+        "locations": locations,
+        "comparison": mapped_intent == "location_comparison",
+        "damage_filter": damage_filter,
+        "needs_map": wants_navigation or mapped_intent == "location_query",
+        "scope": infer_scope(primary_location, explicit_scene_id),
+        "entity_type": entity_type,
+        "explicit_scene_id": explicit_scene_id,
+        "wants_summary": wants_summary,
+        "wants_all_buildings": is_all_buildings_query(question),
+        "advisory": detect_advisory(question),
+        "query_mode": query_mode,
+        "primary_location": primary_location,
+        "raw_question": question,
+    }
+
+
 def format_city_damage_stats(rows):
     if len(rows) == 0:
         return "I couldn't find any city-level address data in the dataset."
@@ -2029,9 +2176,15 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
 
-    intent = classify_query_intent(question)
+    parsed_query = parse_structured_query(question)
+    intent = parsed_query["intent"]
+    damage_type = parsed_query["damage_filter"] or "major-damage"
+    wants_all_buildings = parsed_query["wants_all_buildings"]
+    primary_location = parsed_query["primary_location"]
+    advisory = parsed_query["advisory"]
+    xbd_query_id = parsed_query["explicit_scene_id"]
 
-    if intent == "vlm":
+    if intent == "vlm_query":
         answer = vlm_guidance_response()
         save_turn(question, answer)
         return {
@@ -2113,9 +2266,8 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    comparison_locations = extract_comparison_locations(question)
-    if intent == "location_comparison" and comparison_locations:
-        first_location, second_location = comparison_locations
+    if intent == "location_comparison" and len(parsed_query["locations"]) >= 2:
+        first_location, second_location = parsed_query["locations"][:2]
         first_geo, first_label, first_buildings = resolve_location_buildings(first_location)
         second_geo, second_label, second_buildings = resolve_location_buildings(second_location)
 
@@ -2134,10 +2286,8 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    percentage_location_text = extract_percentage_location_text(question)
-    if intent == "location_percentage" and percentage_location_text:
-        _, damage_type = parse_question(question)
-        geo, label_text, all_buildings = resolve_location_buildings(percentage_location_text)
+    if intent == "location_percentage" and primary_location:
+        geo, label_text, all_buildings = resolve_location_buildings(primary_location)
         matching_buildings = filter_buildings_by_damage(all_buildings, damage_type)
         answer = synthesize_percentage_answer(
             label_text,
@@ -2154,12 +2304,11 @@ def handle_chat_query(question):
             "action": build_no_action(),
         }
 
-    general_location_text = extract_general_location_text(question)
-    if intent == "general_location_overview" and general_location_text:
-        geo, label_text, all_buildings = resolve_location_buildings(general_location_text)
+    if intent == "location_overview" and primary_location:
+        geo, label_text, all_buildings = resolve_location_buildings(primary_location)
 
         if len(all_buildings) == 0:
-            answer = f"I could not find relevant damage data for {general_location_text}."
+            answer = f"I could not find relevant damage data for {primary_location}."
             save_turn(question, answer)
             return {
                 "answer": answer,
@@ -2193,7 +2342,7 @@ def handle_chat_query(question):
         }
             
     # full dataset summary does not have a single map focus
-    if intent == "full_dataset_summary":
+    if intent == "dataset_overview":
         counts = get_full_dataset_damage_counts()
         answer = synthesize_location_overview_answer("the full dataset", counts)
         save_turn(question, answer)
@@ -2205,11 +2354,7 @@ def handle_chat_query(question):
             "action": build_no_action()  # full dataset does not navigate to one route
         }
 
-    _, damage_type = parse_question(question)
-    wants_all_buildings = is_all_buildings_query(question)
-    xbd_query_id = extract_xbd_query_id(question)
-
-    if xbd_query_id is not None:
+    if intent == "scene_query" and xbd_query_id is not None:
         requested_damage = None if wants_all_buildings else damage_type
         buildings = get_buildings_for_xbd(xbd_query_id, requested_damage)
 
@@ -2254,8 +2399,8 @@ def handle_chat_query(question):
             "action": action,
         }
 
-    on_location_text = extract_on_location_text(question)
-    if on_location_text and "near" not in question.lower():
+    if intent == "location_query" and parsed_query["query_mode"] == "on_address" and primary_location:
+        on_location_text = primary_location
         has_explicit_region = "," in on_location_text
         requested_damage = None if wants_all_buildings else damage_type
         buildings = get_buildings_on_address_text(on_location_text, requested_damage)
@@ -2302,8 +2447,8 @@ def handle_chat_query(question):
             "action": action
         }
 
-    address_filter_text = extract_address_filter_text(question)
-    if address_filter_text:
+    if intent == "location_query" and parsed_query["query_mode"] == "address_filter" and primary_location:
+        address_filter_text = primary_location
         buildings = get_buildings_by_address_text(address_filter_text, damage_type)
         primary_xbd_id = get_dominant_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
@@ -2345,8 +2490,8 @@ def handle_chat_query(question):
             "action": action
         }
 
-    in_location_text = extract_in_location_text(question)
-    if in_location_text and "near" not in question.lower():
+    if intent == "location_query" and parsed_query["query_mode"] == "in_location" and primary_location:
+        in_location_text = primary_location
         geo = geocode_address(in_location_text)
         buildings = []
         if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
@@ -2395,8 +2540,19 @@ def handle_chat_query(question):
             "action": action
         }
 
-    # location-based queries
-    address, damage_type = parse_question(question)
+    # generic location-based queries
+    address = primary_location
+    if not address:
+        answer = "I could not determine which location or scene you meant."
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
     geo = geocode_address(address)
 
     if not geo:
@@ -2410,7 +2566,7 @@ def handle_chat_query(question):
         scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
         scene_filtered_buildings = get_buildings_for_primary_scene(filtered_buildings, primary_filtered_xbd_id)
 
-        if is_data_summary_query(question):
+        if parsed_query["wants_summary"]:
             counts = count_damage_levels(all_buildings)
             answer = format_damage_count_response(counts, address)
             action = (
@@ -2428,7 +2584,6 @@ def handle_chat_query(question):
             save_turn(question, answer)
             return payload
 
-        advisory = detect_advisory(question)
         if advisory:
             if len(all_buildings) == 0:
                 answer = f"I couldn't find enough nearby damage data to give a reliable advisory for {address}."
@@ -2481,7 +2636,7 @@ def handle_chat_query(question):
 
 
     # city/street overall damage summary
-    if is_data_summary_query(question):
+    if parsed_query["wants_summary"]:
         all_buildings = get_all_buildings_near(
             geo["lon"],
             geo["lat"],
@@ -2510,8 +2665,6 @@ def handle_chat_query(question):
         return payload
 
     # advisory questions use all nearby damage levels
-    advisory = detect_advisory(question)
-
     if advisory:
         all_buildings = get_all_buildings_near(
             geo["lon"],

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -3,6 +3,7 @@ import psycopg  # used to connect to PostgreSQL (Supabase)
 import requests  # used to make HTTP API calls (Mapbox + Nemotron)
 import os  # used to access environment variables
 import json  # used to convert GeoJSON text from PostGIS into a real Python dictionary
+from pathlib import Path
 from urllib.parse import quote  # used to safely encode values inside frontend route URLs
 from dotenv import load_dotenv  # used to load .env file
 
@@ -21,7 +22,8 @@ def save_turn(question, answer):
     chat_history.append({"role": "assistant", "content": answer})
 
 # loading environment variables from backend/.env file so secrets are not hardcoded
-load_dotenv("backend/.env", override=True)
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(BACKEND_DIR / ".env", override=True)
 
 
 # default disaster name used when building frontend map routes

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -424,7 +424,10 @@ def fetch_city_damage_stats(limit=20):
       SUM(CASE WHEN b.predicted_damage = 'major-damage' THEN 1 ELSE 0 END) AS major_damage,
       SUM(CASE WHEN b.predicted_damage = 'destroyed' THEN 1 ELSE 0 END) AS destroyed
     FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    JOIN disasters d ON ip.disaster_id = d.id
     WHERE b.address IS NOT NULL
+      AND d.name = %s
       AND POSITION(',' IN b.address) > 0
       AND POSITION(',' IN SUBSTRING(b.address FROM POSITION(',' IN b.address) + 1)) > 0
     GROUP BY TRIM(SPLIT_PART(b.address, ',', 2))
@@ -433,7 +436,7 @@ def fetch_city_damage_stats(limit=20):
     LIMIT %s
     """
 
-    cur.execute(query, (limit,))
+    cur.execute(query, (DEFAULT_DISASTER_NAME, limit))
     rows = cur.fetchall()
 
     cur.close()
@@ -619,7 +622,7 @@ def format_damage_count_response(counts, location_text):
     total = sum(counts.values())
 
     if total == 0:
-        return f"I couldn’t find damage assessment data for {location_text}."
+        return f"I couldn't find damage assessment data for {location_text}."
 
     known_total = (
         counts.get("no-damage", 0)
@@ -642,6 +645,35 @@ def format_damage_count_response(counts, location_text):
         response += f", with {other_total} other or unlabeled records"
 
     return response + "."
+
+
+def format_damage_bullet_summary(counts, location_text):
+    total = sum(counts.values())
+
+    if total == 0:
+        return f"I couldn't find damage assessment data for {location_text}."
+
+    known_total = (
+        counts.get("no-damage", 0)
+        + counts.get("minor-damage", 0)
+        + counts.get("major-damage", 0)
+        + counts.get("destroyed", 0)
+    )
+    other_total = total - known_total
+
+    lines = [
+        f"Here's the dataset summary for {location_text}:",
+        f"- Total buildings: {total}",
+        f"- No damage: {counts.get('no-damage', 0)}",
+        f"- Minor damage: {counts.get('minor-damage', 0)}",
+        f"- Major damage: {counts.get('major-damage', 0)}",
+        f"- Destroyed: {counts.get('destroyed', 0)}",
+    ]
+
+    if other_total > 0:
+        lines.append(f"- Other or unlabeled: {other_total}")
+
+    return "\n".join(lines)
 
 
 
@@ -813,7 +845,7 @@ def fallback_advisory_response(buildings, address):
     severe_total = counts.get("major-damage", 0) + counts.get("destroyed", 0)
 
     if total == 0:
-        return f"I couldn’t find enough nearby damage data to assess conditions around {address}."
+        return f"I couldn't find enough nearby damage data to assess conditions around {address}."
     if severe_total > 0:
         return (
             f"Damage near {address} includes {severe_total} severely affected buildings, "
@@ -830,7 +862,7 @@ def fallback_damage_summary(buildings, address):
     total = sum(counts.values())
 
     if total == 0:
-        return f"I couldn’t find damage assessment data for {address}."
+        return f"I couldn't find damage assessment data for {address}."
 
     return (
         f"For {address}, I found {total} buildings total: "
@@ -987,19 +1019,25 @@ def is_city_list_query(question):
     return any(k in q for k in [
         "what cities are in the dataset",
         "which cities are in the dataset",
+        "what cities are in the data",
+        "which cities are in the data",
+        "what cities are in data",
+        "which cities are in data",
         "what cities are affected",
         "which cities were affected",
         "what cities were affected",
         "which cities are affected",
         "list the affected cities",
         "list cities in the dataset",
+        "list cities in the data",
         "what locations are in the dataset",
+        "what locations are in the data",
     ])
 
 
 def format_city_damage_stats(rows):
     if len(rows) == 0:
-        return "I couldn’t find any city-level address data in the dataset."
+        return "I couldn't find any city-level address data in the dataset."
 
     summary_parts = []
     for row in rows[:8]:
@@ -1073,6 +1111,55 @@ Do not use bullet points.
     return call_nemotron(prompt) or (
         fallback if fallback else "No conversation to summarize yet."
     )
+
+
+def fallback_damage_summary(buildings, address):
+    counts = count_damage_levels(buildings)
+    return format_damage_bullet_summary(counts, address)
+
+
+def format_city_damage_stats(rows):
+    if len(rows) == 0:
+        return "I couldn't find any city-level address data in the dataset."
+
+    lines = ["Cities in the dataset include:"]
+    for row in rows[:8]:
+        city = row[0]
+        total = row[1]
+        destroyed = row[5]
+        major = row[4]
+        lines.append(
+            f"- {city}: {total} total, {major} major-damage, {destroyed} destroyed"
+        )
+
+    return "\n".join(lines)
+
+
+def summarize_damage_data(buildings, address):
+    counts = {}
+
+    for b in buildings:
+        d = b["damage"]
+        counts[d] = counts.get(d, 0) + 1
+
+    prompt = f"""
+You are summarizing disaster damage data.
+
+Location: {address}
+Damage breakdown: {counts}
+
+Write a concise summary of the situation.
+
+- Do NOT say "assistant"
+- Do NOT refer to yourself
+- Speak directly
+- Describe severity and impact
+- Prefer 3-5 short bullet points when the breakdown is multi-part
+
+Keep it concise.
+"""
+
+    return call_nemotron(prompt) or fallback_damage_summary(buildings, address)
 
 
 
@@ -1160,7 +1247,7 @@ def handle_chat_query(question):
         primary_xbd_id = get_primary_xbd_id(all_buildings)
         label_text = geo["formatted_address"] if geo else general_location_text
         counts = count_damage_levels(all_buildings)
-        answer = format_damage_count_response(counts, label_text)
+        answer = format_damage_bullet_summary(counts, label_text)
 
         save_turn(question, answer)
         return {
@@ -1187,7 +1274,7 @@ def handle_chat_query(question):
     # full dataset summary does not have a single map focus
     if is_full_dataset_query(question):
         counts = get_full_dataset_damage_counts()
-        answer = format_damage_count_response(counts, "the full dataset")
+        answer = format_damage_bullet_summary(counts, "the full dataset")
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -1328,7 +1415,7 @@ def handle_chat_query(question):
         advisory = detect_advisory(question)
         if advisory:
             if len(all_buildings) == 0:
-                answer = f"I couldn’t find enough nearby damage data to give a reliable advisory for {address}."
+                answer = f"I couldn't find enough nearby damage data to give a reliable advisory for {address}."
                 action = build_no_action()
             else:
                 answer = advisory_response(question, all_buildings, address)
@@ -1434,7 +1521,7 @@ def handle_chat_query(question):
         )
 
         if len(all_buildings) == 0:
-            answer = "I couldn’t find enough nearby damage data to give a reliable advisory for that area."
+            answer = "I couldn't find enough nearby damage data to give a reliable advisory for that area."
             action = build_no_action()
         else:
             answer = advisory_response(question, all_buildings, geo["formatted_address"])

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -4378,10 +4378,7 @@ def handle_chat_query(question, session_id=None):
     if not geo:
         display_address = format_location_label(address)
         all_buildings = get_all_buildings_by_address_text(address)
-        filtered_buildings = [
-            b for b in all_buildings
-            if b.get("damage") == damage_type
-        ]
+        filtered_buildings = filter_buildings_by_damage(all_buildings, damage_type)
         primary_all_xbd_id = get_dominant_xbd_id(all_buildings)
         primary_filtered_xbd_id = get_dominant_xbd_id(filtered_buildings)
         scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -1,4 +1,5 @@
 # importing libraries needed for database, API calls, and environment variables
+from collections import OrderedDict
 from contextvars import ContextVar
 import logging
 import psycopg  # used to connect to PostgreSQL (Supabase)
@@ -21,13 +22,14 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CHAT_SESSION_ID = "default"
 MAX_CHAT_HISTORY_MESSAGES = 40
+MAX_CHAT_HISTORY_SESSIONS = 100
 DEFAULT_NEMOTRON_MODEL = "mistralai/mistral-nemotron"
 DEFAULT_NEMOTRON_FALLBACK_MODEL = ""
 _active_chat_session_id = ContextVar(
     "active_chat_session_id",
     default=DEFAULT_CHAT_SESSION_ID,
 )
-chat_histories = {}
+chat_histories = OrderedDict()
 
 
 def set_active_chat_session(session_id=None):
@@ -37,7 +39,17 @@ def set_active_chat_session(session_id=None):
 
 def get_chat_history():
     session_id = _active_chat_session_id.get()
-    return chat_histories.setdefault(session_id, [])
+    history = chat_histories.get(session_id)
+    if history is None:
+        history = []
+        chat_histories[session_id] = history
+    else:
+        chat_histories.move_to_end(session_id)
+
+    while len(chat_histories) > MAX_CHAT_HISTORY_SESSIONS:
+        chat_histories.popitem(last=False)
+
+    return history
 
 
 def save_turn(question, answer):

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -3,6 +3,7 @@ import psycopg  # used to connect to PostgreSQL (Supabase)
 import requests  # used to make HTTP API calls (Mapbox + Nemotron)
 import os  # used to access environment variables
 import json  # used to convert GeoJSON text from PostGIS into a real Python dictionary
+import random
 import re
 from pathlib import Path
 from urllib.parse import quote  # used to safely encode values inside frontend route URLs
@@ -393,14 +394,18 @@ def get_buildings_by_address_text(address_text, damage_filter):
     address_parts = [part.strip() for part in address_clean.split(",") if part.strip()]
     city_part = address_parts[0] if len(address_parts) > 0 else address_clean
     region_part = address_parts[1] if len(address_parts) > 1 else None
-    region_aliases = {
+    region_aliases: dict[str, list[str]] = {
         "texas": ["texas", "tx"],
     }
     city_pattern = re.escape(city_part)
-    region_patterns = [
-        re.escape(alias)
-        for alias in region_aliases.get(region_part.lower(), [region_part])
-    ] if region_part else []
+    region_values: list[str] = []
+    if region_part:
+        normalized_region_part = str(region_part)
+        region_values = region_aliases.get(
+            normalized_region_part.lower(),
+            [normalized_region_part],
+        )
+    region_patterns = [re.escape(alias) for alias in region_values]
     city_state_pattern = (
         rf"\b{city_pattern}\b(?:\s*,\s*|\s+)(?:{'|'.join(region_patterns)})\b"
         if region_patterns
@@ -434,14 +439,18 @@ def get_all_buildings_by_address_text(address_text):
     address_parts = [part.strip() for part in address_clean.split(",") if part.strip()]
     city_part = address_parts[0] if len(address_parts) > 0 else address_clean
     region_part = address_parts[1] if len(address_parts) > 1 else None
-    region_aliases = {
+    region_aliases: dict[str, list[str]] = {
         "texas": ["texas", "tx"],
     }
     city_pattern = re.escape(city_part)
-    region_patterns = [
-        re.escape(alias)
-        for alias in region_aliases.get(region_part.lower(), [region_part])
-    ] if region_part else []
+    region_values: list[str] = []
+    if region_part:
+        normalized_region_part = str(region_part)
+        region_values = region_aliases.get(
+            normalized_region_part.lower(),
+            [normalized_region_part],
+        )
+    region_patterns = [re.escape(alias) for alias in region_values]
     city_state_pattern = (
         rf"\b{city_pattern}\b(?:\s*,\s*|\s+)(?:{'|'.join(region_patterns)})\b"
         if region_patterns
@@ -466,8 +475,8 @@ def get_all_buildings_by_address_text(address_text):
     return rows_to_buildings(rows)
 
 
-def build_map_action_from_buildings(buildings, address_text=None):
-    primary_xbd_id = get_primary_xbd_id(buildings)
+def build_map_action_from_buildings(buildings, address_text=None, primary_xbd_id=None):
+    primary_xbd_id = primary_xbd_id if primary_xbd_id is not None else get_primary_xbd_id(buildings)
 
     return {
         "type": "navigate",
@@ -484,22 +493,20 @@ def build_map_action_from_buildings(buildings, address_text=None):
 
 
 def get_primary_xbd_id(buildings):
-    xbd_counts = {}
+    xbd_ids = sorted({
+        building.get("xbd_id")
+        for building in buildings
+        if building.get("xbd_id") is not None
+    })
 
-    for building in buildings:
-        xbd_id = building.get("xbd_id")
-        if xbd_id is None:
-            continue
-        xbd_counts[xbd_id] = xbd_counts.get(xbd_id, 0) + 1
-
-    if not xbd_counts:
+    if not xbd_ids:
         return None
 
-    return max(sorted(xbd_counts), key=lambda xbd_id: xbd_counts[xbd_id])
+    return random.choice(xbd_ids)
 
 
-def get_buildings_for_primary_scene(buildings):
-    primary_xbd_id = get_primary_xbd_id(buildings)
+def get_buildings_for_primary_scene(buildings, primary_xbd_id=None):
+    primary_xbd_id = primary_xbd_id if primary_xbd_id is not None else get_primary_xbd_id(buildings)
     if primary_xbd_id is None:
         return []
 
@@ -1055,7 +1062,8 @@ def handle_chat_query(question):
     address_filter_text = extract_address_filter_text(question)
     if address_filter_text:
         buildings = get_buildings_by_address_text(address_filter_text, damage_type)
-        scene_buildings = get_buildings_for_primary_scene(buildings)
+        primary_xbd_id = get_primary_xbd_id(buildings)
+        scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
         geo = geocode_address(address_filter_text)
 
         if len(buildings) == 0:
@@ -1082,18 +1090,14 @@ def handle_chat_query(question):
         action = (
             build_building_action(buildings[0])
             if len(buildings) == 1
-            else build_map_action_from_buildings(buildings, label_text)
+            else build_map_action_from_buildings(buildings, label_text, primary_xbd_id)
         )
 
         save_turn(question, answer)
         return {
             "answer": answer,
             "response": answer,
-            "focus": {
-                "lat": geo["lat"],
-                "lon": geo["lon"],
-                "address": geo["formatted_address"]
-            } if geo else None,
+            "focus": None,
             "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
             "action": action
         }
@@ -1113,7 +1117,8 @@ def handle_chat_query(question):
             )
         if len(buildings) == 0:
             buildings = get_buildings_by_address_text(in_location_text, damage_type)
-        scene_buildings = get_buildings_for_primary_scene(buildings)
+        primary_xbd_id = get_primary_xbd_id(buildings)
+        scene_buildings = get_buildings_for_primary_scene(buildings, primary_xbd_id)
 
         if len(buildings) == 0:
             answer = f"I could not find relevant damage data for {in_location_text}."
@@ -1121,11 +1126,7 @@ def handle_chat_query(question):
             return {
                 "answer": answer,
                 "response": answer,
-                "focus": {
-                    "lat": geo["lat"],
-                    "lon": geo["lon"],
-                    "address": geo["formatted_address"]
-                } if geo else None,
+                "focus": None,
                 "highlighted_buildings": [],
                 "action": build_no_action()
             }
@@ -1139,18 +1140,14 @@ def handle_chat_query(question):
         action = (
             build_building_action(buildings[0])
             if len(buildings) == 1
-            else build_map_action_from_buildings(buildings, label_text)
+            else build_map_action_from_buildings(buildings, label_text, primary_xbd_id)
         )
 
         save_turn(question, answer)
         return {
             "answer": answer,
             "response": answer,
-            "focus": {
-                "lat": geo["lat"],
-                "lon": geo["lon"],
-                "address": geo["formatted_address"]
-            } if geo else None,
+            "focus": None,
             "highlighted_buildings": scene_buildings if len(buildings) > 1 else buildings,
             "action": action
         }
@@ -1165,14 +1162,16 @@ def handle_chat_query(question):
             b for b in all_buildings
             if b.get("damage") == damage_type
         ]
-        scene_all_buildings = get_buildings_for_primary_scene(all_buildings)
-        scene_filtered_buildings = get_buildings_for_primary_scene(filtered_buildings)
+        primary_all_xbd_id = get_primary_xbd_id(all_buildings)
+        primary_filtered_xbd_id = get_primary_xbd_id(filtered_buildings)
+        scene_all_buildings = get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
+        scene_filtered_buildings = get_buildings_for_primary_scene(filtered_buildings, primary_filtered_xbd_id)
 
         if is_data_summary_query(question):
             counts = count_damage_levels(all_buildings)
             answer = format_damage_count_response(counts, address)
             action = (
-                build_map_action_from_buildings(all_buildings, address)
+                build_map_action_from_buildings(all_buildings, address, primary_all_xbd_id)
                 if len(all_buildings) > 0
                 else build_no_action()
             )
@@ -1193,7 +1192,7 @@ def handle_chat_query(question):
                 action = build_no_action()
             else:
                 answer = advisory_response(question, all_buildings, address)
-                action = build_map_action_from_buildings(all_buildings, address)
+                action = build_map_action_from_buildings(all_buildings, address, primary_all_xbd_id)
 
             payload = {
                 "answer": answer,
@@ -1224,7 +1223,7 @@ def handle_chat_query(question):
         action = (
             build_building_action(filtered_buildings[0])
             if len(filtered_buildings) == 1
-            else build_map_action_from_buildings(filtered_buildings, address)
+            else build_map_action_from_buildings(filtered_buildings, address, primary_filtered_xbd_id)
         )
 
         payload = {
@@ -1248,8 +1247,9 @@ def handle_chat_query(question):
         used_address_fallback = len(all_buildings) == 0
         if used_address_fallback:
             all_buildings = get_all_buildings_by_address_text(address)
+        primary_all_xbd_id = get_primary_xbd_id(all_buildings)
         scene_all_buildings = (
-            get_buildings_for_primary_scene(all_buildings)
+            get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
             if used_address_fallback
             else all_buildings
         )
@@ -1262,7 +1262,11 @@ def handle_chat_query(question):
         )
 
         # create a map navigation action so frontend can route/focus to the result area
-        action = build_map_action(geo, all_buildings)
+        action = (
+            build_map_action_from_buildings(all_buildings, geo["formatted_address"], primary_all_xbd_id)
+            if used_address_fallback
+            else build_map_action(geo, all_buildings)
+        )
 
         # package chatbot answer, map focus, highlighted buildings, and navigation action
         payload = build_map_payload(answer, geo, scene_all_buildings, action)
@@ -1282,8 +1286,9 @@ def handle_chat_query(question):
         used_address_fallback = len(all_buildings) == 0
         if used_address_fallback:
             all_buildings = get_all_buildings_by_address_text(address)
+        primary_all_xbd_id = get_primary_xbd_id(all_buildings)
         scene_all_buildings = (
-            get_buildings_for_primary_scene(all_buildings)
+            get_buildings_for_primary_scene(all_buildings, primary_all_xbd_id)
             if used_address_fallback
             else all_buildings
         )
@@ -1295,7 +1300,11 @@ def handle_chat_query(question):
             answer = advisory_response(question, all_buildings, geo["formatted_address"])
 
             # create a map navigation action because advisory answers still relate to this location
-            action = build_map_action(geo, all_buildings)
+            action = (
+                build_map_action_from_buildings(all_buildings, geo["formatted_address"], primary_all_xbd_id)
+                if used_address_fallback
+                else build_map_action(geo, all_buildings)
+            )
 
         # package chatbot answer, map focus, highlighted buildings, and navigation action
         payload = build_map_payload(answer, geo, scene_all_buildings, action)
@@ -1314,8 +1323,9 @@ def handle_chat_query(question):
     used_address_fallback = len(buildings) == 0
     if used_address_fallback:
         buildings = get_buildings_by_address_text(address, damage_type)
+    primary_buildings_xbd_id = get_primary_xbd_id(buildings)
     scene_buildings = (
-        get_buildings_for_primary_scene(buildings)
+        get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
         if used_address_fallback
         else buildings
     )
@@ -1346,7 +1356,11 @@ def handle_chat_query(question):
 
     # if multiple buildings matched, frontend should route/focus to the map view
     else:
-        action = build_map_action(geo, buildings)
+        action = (
+            build_map_action_from_buildings(buildings, geo["formatted_address"], primary_buildings_xbd_id)
+            if used_address_fallback
+            else build_map_action(geo, buildings)
+        )
 
     # package chatbot answer, map focus, highlighted buildings, and navigation action
     payload = build_map_payload(answer, geo, scene_buildings, action)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -34,6 +34,7 @@ load_dotenv(BACKEND_DIR / ".env", override=True)
 DEFAULT_DISASTER_NAME = os.getenv("DEFAULT_DISASTER_NAME", "hurricane-harvey")
 STREET_ADDRESS_OVERVIEW_RADIUS_M = 300
 EXACT_ADDRESS_OVERVIEW_RADIUS_M = 75
+NAMED_LOCATION_OVERVIEW_RADIUS_M = 5000
 
 
 # function to connect to database using environment variables
@@ -548,7 +549,16 @@ def resolve_location_buildings(location_text):
     if not has_explicit_region:
         buildings = get_all_buildings_by_address_text(normalized_location)
         if len(buildings) > 0:
-            return None, normalized_location, buildings
+            if looks_like_street_address(normalized_location):
+                return None, normalized_location, buildings
+
+            geo = geocode_address(
+                f"{normalized_location}, Texas"
+                if DEFAULT_DISASTER_NAME == "hurricane-harvey"
+                else normalized_location
+            )
+            label_text = geo["formatted_address"] if geo else normalized_location
+            return geo, label_text, buildings
         if DEFAULT_DISASTER_NAME == "hurricane-harvey":
             geocode_query = f"{normalized_location}, Texas"
 
@@ -1595,7 +1605,13 @@ def is_full_dataset_query(question):
         "all buildings",
         "overall dataset",
         "dataset summary",
-        "overall damage in the dataset"
+        "overall damage in the dataset",
+        "tell me about the data",
+        "tell me about the dataset",
+        "about the data",
+        "about the dataset",
+        "describe the data",
+        "describe the dataset",
     ])
     if not has_dataset_phrase:
         return False
@@ -2336,29 +2352,34 @@ def handle_chat_query(question):
         save_turn(question, answer)
         return payload
 
-    # exact damage count questions use filtered buildings
-    buildings = get_buildings_near(
-        geo["lon"],
-        geo["lat"],
-        5000,
-        damage_type
+    resolved_geo, resolved_label_text, all_buildings = resolve_location_buildings(
+        address
     )
-    all_nearby_buildings = get_all_buildings_near(
-        geo["lon"],
-        geo["lat"],
-        5000
-    )
-    used_address_fallback = len(buildings) == 0
-    if used_address_fallback:
-        buildings = get_buildings_by_address_text(address, damage_type)
+    map_geo = resolved_geo or geo
+    location_label = resolved_label_text or geo["formatted_address"]
+
+    if len(all_buildings) == 0 and geo:
+        all_buildings = get_all_buildings_near(
+            geo["lon"],
+            geo["lat"],
+            NAMED_LOCATION_OVERVIEW_RADIUS_M,
+        )
+        if len(all_buildings) > 0:
+            resolved_geo = geo
+            map_geo = geo
+            location_label = geo["formatted_address"]
+
+    # exact damage count queries should count from the full resolved location set,
+    # then choose one representative scene only for map visualization.
+    buildings = filter_buildings_by_damage(all_buildings, damage_type)
     primary_buildings_xbd_id = (
-        get_nearest_xbd_id(all_nearby_buildings)
-        if len(all_nearby_buildings) > 0
-        else get_nearest_xbd_id(buildings)
+        get_primary_xbd_id(buildings)
+        if len(buildings) > 0
+        else get_primary_xbd_id(all_buildings)
     )
     scene_buildings = get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
     if len(scene_buildings) == 0:
-        primary_buildings_xbd_id = get_nearest_xbd_id(buildings)
+        primary_buildings_xbd_id = get_primary_xbd_id(buildings)
         scene_buildings = get_buildings_for_primary_scene(buildings, primary_buildings_xbd_id)
 
     if len(buildings) == 0:
@@ -2368,18 +2389,18 @@ def handle_chat_query(question):
             "answer": answer,  # chatbot response text
             "response": answer,  # same text for frontend compatibility
             "focus": {
-                "lat": geo["lat"],  # latitude of the searched location
-                "lon": geo["lon"],  # longitude of the searched location
-                "address": geo["formatted_address"]  # readable searched address
+                "lat": map_geo["lat"],  # latitude of the searched location
+                "lon": map_geo["lon"],  # longitude of the searched location
+                "address": map_geo["formatted_address"]  # readable searched address
             },
             "highlighted_buildings": [],  # no buildings matched
             "action": build_no_action()  # no navigation target because no building was found
         }
 
     if damage_type == "no-damage":
-        answer = f"{len(buildings)} buildings in {geo['formatted_address']} appear to have no visible damage."
+        answer = f"{len(buildings)} buildings in {location_label} appear to have no visible damage."
     else:
-        answer = generate_llm_answer(buildings, geo["formatted_address"], damage_type)
+        answer = generate_llm_answer(buildings, location_label, damage_type)
 
     # if only one building matched, frontend can route directly to that building
     if len(buildings) == 1:
@@ -2387,10 +2408,14 @@ def handle_chat_query(question):
 
     # if multiple buildings matched, frontend should route/focus to the map view
     else:
-        action = build_map_action_from_buildings(buildings, geo["formatted_address"], primary_buildings_xbd_id)
+        action = build_map_action_from_buildings(
+            buildings,
+            location_label,
+            primary_buildings_xbd_id,
+        )
 
     # package chatbot answer, map focus, highlighted buildings, and navigation action
-    payload = build_map_payload(answer, geo, scene_buildings, action)
+    payload = build_map_payload(answer, map_geo, scene_buildings, action)
     save_turn(question, answer)
     return payload
 

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -121,7 +121,9 @@ def rows_to_buildings(rows):
             "uid": building_uid,  # exact field frontend uses for building route
             "xbd_id": xbd_id,  # image pair id used in /map/:disasterName/:xbd_id
             "damage": damage,  # damage level used for filtering/color-coding
-            "geometry": geometry  # GeoJSON polygon object for Mapbox
+            "geometry": geometry,  # GeoJSON polygon object for Mapbox
+            "actual_damage": r[4] if len(r) > 4 else None,
+            "is_correct": r[5] if len(r) > 5 else None,
         })
 
     return buildings
@@ -149,7 +151,7 @@ def parse_question(question):
     # extract location from common location phrases
     location_match = re.search(
         r"\b(?:near|in)\s+(.+?)(?:\?|$)",
-        q,
+        question,
         flags=re.IGNORECASE,
     )
 
@@ -246,6 +248,9 @@ def extract_general_location_text(question):
         r"give me stats for\s+(.+?)(?:\?|$)",
         r"give me information about\s+(.+?)(?:\?|$)",
         r"overview of\s+(.+?)(?:\?|$)",
+        r"(?:damage summary|summary of damage|overall damage|damage breakdown|damage levels)\s+for\s+(.+?)(?:\?|$)",
+        r"(?:damage summary|summary of damage|overall damage|damage breakdown|damage levels)\s+near\s+(.+?)(?:\?|$)",
+        r"(?:damage summary|summary of damage|overall damage|damage breakdown|damage levels)\s+in\s+(.+?)(?:\?|$)",
     ]
 
     for pattern in patterns:
@@ -619,6 +624,70 @@ def fetch_city_damage_stats(limit=20):
     return rows
 
 
+def fetch_scene_stats(limit=None):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT
+      ip.xbd_id,
+      COUNT(*) AS total_buildings,
+      COALESCE(SUM(CASE WHEN b.predicted_damage = 'no-damage' THEN 1 ELSE 0 END), 0) AS no_damage,
+      COALESCE(SUM(CASE WHEN b.predicted_damage = 'minor-damage' THEN 1 ELSE 0 END), 0) AS minor_damage,
+      COALESCE(SUM(CASE WHEN b.predicted_damage = 'major-damage' THEN 1 ELSE 0 END), 0) AS major_damage,
+      COALESCE(SUM(CASE WHEN b.predicted_damage = 'destroyed' THEN 1 ELSE 0 END), 0) AS destroyed,
+      COALESCE(SUM(CASE
+        WHEN b.predicted_damage IS NOT NULL
+         AND b.actual_damage::text = b.predicted_damage::text
+        THEN 1 ELSE 0 END), 0) AS correct_count,
+      COALESCE(SUM(CASE
+        WHEN b.predicted_damage IS NOT NULL
+        THEN 1 ELSE 0 END), 0) AS compared_count,
+      COALESCE(SUM(CASE
+        WHEN b.predicted_damage IS NOT NULL
+         AND b.actual_damage::text <> b.predicted_damage::text
+        THEN 1 ELSE 0 END), 0) AS incorrect_count
+    FROM image_pairs ip
+    JOIN disasters d ON ip.disaster_id = d.id
+    LEFT JOIN buildings b ON b.image_pair_id = ip.id
+    WHERE d.name = %s
+    GROUP BY ip.xbd_id
+    """
+
+    params = [DEFAULT_DISASTER_NAME]
+    if limit is not None:
+        query += " ORDER BY ip.xbd_id ASC LIMIT %s"
+        params.append(limit)
+
+    cur.execute(query, tuple(params))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows
+
+
+def fetch_scene_count():
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT COUNT(*)
+    FROM image_pairs ip
+    JOIN disasters d ON ip.disaster_id = d.id
+    WHERE d.name = %s
+    """
+
+    cur.execute(query, (DEFAULT_DISASTER_NAME,))
+    row = cur.fetchone()
+
+    cur.close()
+    conn.close()
+
+    return row[0] if row else 0
+
+
 def format_city_list_response(rows):
     if len(rows) == 0:
         return "I couldn't find any city-level data for the active disaster dataset."
@@ -679,9 +748,13 @@ def resolve_location_buildings(location_text):
         buildings = get_all_buildings_by_address_text(normalized_location)
 
     if len(buildings) > 0 and not has_explicit_region:
-        label_text = normalized_location
+        label_text = format_location_label(normalized_location)
     else:
-        label_text = geo["formatted_address"] if geo else normalized_location
+        label_text = (
+            format_location_label(geo["formatted_address"])
+            if geo and geo.get("formatted_address")
+            else format_location_label(normalized_location)
+        )
 
     return geo, label_text, buildings
 
@@ -770,6 +843,63 @@ def is_city_ranking_query(question):
     return any(signal in q for signal in ranking_signals)
 
 
+def is_scene_count_query(question):
+    q = question.lower()
+    return (
+        "how many scenes" in q
+        or "number of scenes" in q
+        or "how many xbd scenes" in q
+        or "how many image pairs" in q
+        or "how many xbd ids" in q
+    )
+
+
+def is_scene_ranking_query(question):
+    q = question.lower()
+    scene_terms = ["scene", "scenes", "xbd", "image pair", "image pairs"]
+    ranking_terms = [
+        "worst",
+        "best",
+        "most",
+        "highest",
+        "lowest",
+        "top",
+        "rank",
+    ]
+    metric_terms = [
+        "accuracy",
+        "destroyed",
+        "major damage",
+        "minor damage",
+        "incorrect",
+        "wrong predictions",
+        "misclassified",
+    ]
+    return (
+        any(term in q for term in scene_terms)
+        and any(term in q for term in ranking_terms)
+        and any(term in q for term in metric_terms)
+    )
+
+
+def is_misclassified_query(question):
+    q = question.lower()
+    return any(
+        term in q
+        for term in [
+            "misclassified",
+            "wrong prediction",
+            "wrong predictions",
+            "incorrect prediction",
+            "incorrect predictions",
+            "false positives",
+            "false positive",
+            "false negatives",
+            "false negative",
+        ]
+    )
+
+
 def extract_top_n(question, default=5):
     match = re.search(r"\btop\s+(\d+)\b", question, flags=re.IGNORECASE)
     if not match:
@@ -799,6 +929,90 @@ def get_ranking_metric(question):
     ]):
         return "no-damage"
     return "total"
+
+
+def get_scene_ranking_metric(question):
+    q = question.lower()
+    if "accuracy" in q:
+        return "accuracy"
+    if any(term in q for term in ["incorrect", "wrong prediction", "wrong predictions", "misclassified"]):
+        return "incorrect_count"
+    if "destroyed" in q:
+        return "destroyed"
+    if "major" in q:
+        return "major_damage"
+    if "minor" in q:
+        return "minor_damage"
+    return "destroyed"
+
+
+def sort_scene_rows(rows, metric):
+    def sort_key(row):
+        xbd_id, total, _no_damage, minor, major, destroyed, correct, compared, incorrect = row
+        accuracy = (correct / compared) if compared else None
+
+        values = {
+            "destroyed": destroyed,
+            "major_damage": major,
+            "minor_damage": minor,
+            "incorrect_count": incorrect,
+            "accuracy": accuracy if accuracy is not None else 2,
+        }
+        primary = values[metric]
+        if metric == "accuracy":
+            return (primary, -compared, xbd_id)
+        return (-primary, -total, xbd_id)
+
+    return sorted(rows, key=sort_key)
+
+
+def format_scene_count_response(total_scenes):
+    return f"The active disaster dataset includes {total_scenes} xBD scenes/image pairs."
+
+
+def format_scene_label(scene_id):
+    return f"scene {scene_id}"
+
+
+def format_scene_ranking(rows, metric, limit):
+    if len(rows) == 0:
+        return "I couldn't find any scene-level data for the active disaster dataset."
+
+    sorted_rows = sort_scene_rows(rows, metric)
+    limited_rows = sorted_rows[:limit]
+    metric_label = {
+        "destroyed": "destroyed buildings",
+        "major_damage": "major-damage buildings",
+        "minor_damage": "minor-damage buildings",
+        "incorrect_count": "incorrect predictions",
+        "accuracy": "lowest accuracy",
+    }[metric]
+
+    lines = [f"Top scenes by {metric_label}:"]
+    for row in limited_rows:
+        xbd_id, total, _no_damage, minor, major, destroyed, correct, compared, incorrect = row
+        if metric == "accuracy":
+            accuracy_text = "n/a" if compared == 0 else f"{round((correct / compared) * 100, 1)}%"
+            lines.append(
+                f"- {format_scene_label(xbd_id)}: accuracy {accuracy_text}, {incorrect} incorrect, {total} total"
+            )
+        else:
+            metric_value = {
+                "destroyed": destroyed,
+                "major_damage": major,
+                "minor_damage": minor,
+                "incorrect_count": incorrect,
+            }[metric]
+            lines.append(
+                f"- {format_scene_label(xbd_id)}: {metric_value} {metric_label}, {total} total"
+            )
+
+    return "\n".join(lines)
+
+
+def get_top_scene_for_metric(rows, metric):
+    sorted_rows = sort_scene_rows(rows, metric)
+    return sorted_rows[0] if sorted_rows else None
 
 
 def sort_city_rows(rows, metric):
@@ -1066,6 +1280,74 @@ def get_buildings_for_xbd(xbd_id, damage_filter=None):
     return rows_to_buildings(rows)
 
 
+def get_misclassified_buildings_for_xbd(xbd_id):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT
+      b.uid,
+      ip.xbd_id,
+      b.predicted_damage,
+      ST_AsGeoJSON(b.geom),
+      b.actual_damage::text,
+      CASE
+        WHEN b.predicted_damage IS NULL THEN NULL
+        WHEN b.actual_damage::text = b.predicted_damage::text THEN TRUE
+        ELSE FALSE
+      END AS is_correct
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    JOIN disasters d ON ip.disaster_id = d.id
+    WHERE d.name = %s
+      AND ip.xbd_id = %s
+      AND b.predicted_damage IS NOT NULL
+      AND b.actual_damage::text <> b.predicted_damage::text
+    """
+
+    cur.execute(query, (DEFAULT_DISASTER_NAME, xbd_id))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
+def get_all_misclassified_buildings():
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT
+      b.uid,
+      ip.xbd_id,
+      b.predicted_damage,
+      ST_AsGeoJSON(b.geom),
+      b.actual_damage::text,
+      CASE
+        WHEN b.predicted_damage IS NULL THEN NULL
+        WHEN b.actual_damage::text = b.predicted_damage::text THEN TRUE
+        ELSE FALSE
+      END AS is_correct
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    JOIN disasters d ON ip.disaster_id = d.id
+    WHERE d.name = %s
+      AND b.predicted_damage IS NOT NULL
+      AND b.actual_damage::text <> b.predicted_damage::text
+    ORDER BY ip.xbd_id ASC
+    """
+
+    cur.execute(query, (DEFAULT_DISASTER_NAME,))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows_to_buildings(rows)
+
+
 def get_buildings_by_address_text(address_text, damage_filter):
     conn = get_db_connection()
     cur = conn.cursor()
@@ -1268,7 +1550,11 @@ def get_nearest_xbd_id(buildings):
 
 
 def extract_xbd_query_id(question):
-    match = re.search(r"\bxbd\s*#?\s*(\d+)\b", question, flags=re.IGNORECASE)
+    match = re.search(
+        r"\b(?:xbd|scene)\s*#?\s*(\d+)\b",
+        question,
+        flags=re.IGNORECASE,
+    )
     if not match:
         return None
 
@@ -1748,7 +2034,7 @@ def is_full_dataset_query(question):
     if not has_dataset_phrase:
         return False
 
-    scoped_location_phrases = [" near ", " in ", " on ", " around ", " at "]
+    scoped_location_phrases = [" near ", " in ", " on ", " around ", " at ", " for "]
     return not any(phrase in q for phrase in scoped_location_phrases)
 
 
@@ -1814,6 +2100,15 @@ def classify_query_intent_heuristic(question):
     if is_vlm_query(question):
         return "vlm"
 
+    if is_scene_count_query(question):
+        return "scene_count"
+
+    if is_scene_ranking_query(question):
+        return "scene_ranking"
+
+    if is_misclassified_query(question):
+        return "misclassified_buildings"
+
     if is_conversation_summary_query(question):
         return "conversation_summary"
 
@@ -1832,6 +2127,11 @@ def classify_query_intent_heuristic(question):
     comparison_locations = extract_comparison_locations(question)
     if comparison_locations and is_city_comparison_query(question):
         return "location_comparison"
+
+    if is_data_summary_query(question):
+        if any(phrase in lowered_question for phrase in [" near ", " in ", " on ", " around ", " at ", " for "]):
+            return "general_location_overview"
+        return "full_dataset_summary"
 
     if extract_percentage_location_text(question):
         return "location_percentage"
@@ -1871,6 +2171,9 @@ def classify_query_intent_llm(question):
 You are routing user questions for a disaster damage assessment assistant.
 
 Choose exactly one label from this list:
+- scene_count
+- scene_ranking
+- misclassified_buildings
 - full_dataset_summary
 - city_list
 - city_count
@@ -1887,6 +2190,9 @@ Choose exactly one label from this list:
 
 Definitions:
 - full_dataset_summary: asks about the dataset as a whole, what the data contains, or overall damage across the dataset, without focusing on one place
+- scene_count: asks how many xBD scenes or image pairs are in the dataset
+- scene_ranking: asks for the best/worst/top scenes by accuracy, incorrect predictions, or damage counts
+- misclassified_buildings: asks to show buildings with incorrect predictions or other classification errors
 - city_list: asks which cities or locations appear in the dataset
 - city_count: asks how many cities or locations are represented
 - damage_labels: asks which damage labels or levels exist
@@ -1922,6 +2228,15 @@ Label: general_location_overview
 Question: Show XBD 18
 Label: xbd_query
 
+Question: How many scenes are available?
+Label: scene_count
+
+Question: Show the worst scene by accuracy
+Label: scene_ranking
+
+Question: Show misclassified buildings
+Label: misclassified_buildings
+
 Question: Upload a before and after image
 Label: vlm
 
@@ -1935,6 +2250,9 @@ Label:
 
     label = result.strip().strip('"').strip().splitlines()[0].strip().lower()
     valid_labels = {
+        "scene_count",
+        "scene_ranking",
+        "misclassified_buildings",
         "full_dataset_summary",
         "city_list",
         "city_count",
@@ -2046,6 +2364,9 @@ def parse_structured_query(question):
     raw_intent = classify_query_intent(question)
     mapped_intent = {
         "full_dataset_summary": "dataset_overview",
+        "scene_count": "scene_count",
+        "scene_ranking": "scene_ranking",
+        "misclassified_buildings": "misclassified_buildings",
         "city_list": "city_list",
         "city_count": "city_count",
         "damage_labels": "damage_label_query",
@@ -2114,8 +2435,10 @@ def parse_structured_query(question):
         primary_location = normalize_location_candidate(percentage_location_text)
         locations = [primary_location] if primary_location else []
         query_mode = "percentage"
-    elif mapped_intent == "location_overview" and general_location_text:
-        primary_location = normalize_location_candidate(general_location_text)
+    elif mapped_intent == "location_overview" and (general_location_text or explicit_near_or_in_match):
+        primary_location = normalize_location_candidate(
+            general_location_text if general_location_text else parsed_address
+        )
         locations = [primary_location] if primary_location else []
         query_mode = "overview"
     elif on_location_text:
@@ -2131,7 +2454,7 @@ def parse_structured_query(question):
         locations = [primary_location] if primary_location else []
         query_mode = "in_location"
     elif explicit_scene_id is not None:
-        primary_location = f"XBD {explicit_scene_id}"
+        primary_location = format_scene_label(explicit_scene_id)
         locations = [primary_location]
         query_mode = "scene"
     else:
@@ -2167,6 +2490,8 @@ def parse_structured_query(question):
         "city_count",
         "damage_label_query",
         "conversation_summary",
+        "scene_count",
+        "scene_ranking",
     }
 
     entity_type = "place"
@@ -2393,6 +2718,115 @@ def handle_chat_query(question):
             "action": build_no_action()  # no navigation action
         }
 
+    if intent == "scene_count":
+        total_scenes = fetch_scene_count()
+        answer = format_scene_count_response(total_scenes)
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
+        }
+
+    if intent == "scene_ranking":
+        metric = get_scene_ranking_metric(question)
+        limit = extract_top_n(question)
+        scene_rows = fetch_scene_stats()
+        answer = format_scene_ranking(scene_rows, metric, limit)
+        top_scene = get_top_scene_for_metric(scene_rows, metric)
+
+        if not top_scene:
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
+
+        top_xbd_id = top_scene[0]
+        if metric in {"accuracy", "incorrect_count"}:
+            highlighted_buildings = get_misclassified_buildings_for_xbd(top_xbd_id)
+        elif metric == "destroyed":
+            highlighted_buildings = get_buildings_for_xbd(top_xbd_id, "destroyed")
+        elif metric == "major_damage":
+            highlighted_buildings = get_buildings_for_xbd(top_xbd_id, "major-damage")
+        elif metric == "minor_damage":
+            highlighted_buildings = get_buildings_for_xbd(top_xbd_id, "minor-damage")
+        else:
+            highlighted_buildings = get_buildings_for_xbd(top_xbd_id)
+        action = build_scene_action(
+            top_xbd_id,
+            [building["uid"] for building in highlighted_buildings],
+            format_scene_label(top_xbd_id),
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": highlighted_buildings,
+            "action": action,
+        }
+
+    if intent == "misclassified_buildings":
+        if xbd_query_id is not None:
+            misclassified_buildings = get_misclassified_buildings_for_xbd(xbd_query_id)
+            label_text = format_scene_label(xbd_query_id)
+            total_misclassified = len(misclassified_buildings)
+        else:
+            all_misclassified_buildings = get_all_misclassified_buildings()
+            total_misclassified = len(all_misclassified_buildings)
+            representative_xbd_id = get_dominant_xbd_id(all_misclassified_buildings)
+            misclassified_buildings = get_buildings_for_primary_scene(
+                all_misclassified_buildings,
+                representative_xbd_id,
+            )
+            label_text = (
+                f"representative {format_scene_label(representative_xbd_id)}"
+                if representative_xbd_id is not None
+                else "the active dataset"
+            )
+
+        if len(misclassified_buildings) == 0:
+            if xbd_query_id is not None:
+                answer = f"I couldn't find any misclassified buildings on {format_scene_label(xbd_query_id)}."
+            else:
+                answer = "I couldn't find any misclassified buildings in the active disaster dataset."
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
+
+        answer = f"I found {total_misclassified} misclassified buildings in the active disaster dataset."
+        if xbd_query_id is not None:
+            answer = f"I found {total_misclassified} misclassified buildings on {label_text}."
+        else:
+            answer += f" I'm highlighting {label_text} on the map."
+        primary_xbd_id = get_dominant_xbd_id(misclassified_buildings)
+        action = build_scene_action(
+            primary_xbd_id,
+            [building["uid"] for building in misclassified_buildings],
+            label_text,
+        )
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": misclassified_buildings,
+            "action": action,
+        }
+
     if intent == "city_count":
         rows = fetch_city_damage_stats(limit=500)
         city_total = len(rows)
@@ -2575,7 +3009,7 @@ def handle_chat_query(question):
 
         if len(buildings) == 0:
             answer = (
-                f"I could not find relevant damage data for XBD {xbd_query_id}."
+                f"I could not find relevant damage data for {format_scene_label(xbd_query_id)}."
             )
             save_turn(question, answer)
             return {
@@ -2586,7 +3020,7 @@ def handle_chat_query(question):
                 "action": build_no_action(),
             }
 
-        label_text = f"XBD {xbd_query_id}"
+        label_text = format_scene_label(xbd_query_id)
         if wants_all_buildings:
             counts = count_damage_levels(buildings)
             answer = synthesize_location_overview_answer(label_text, counts)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -618,6 +618,33 @@ def format_city_ranking(rows, metric, limit):
     return "\n".join(lines)
 
 
+def synthesize_city_ranking_answer(rows, metric, limit):
+    fallback = format_city_ranking(rows, metric, limit)
+    metric_label = {
+        "total": "total buildings",
+        "no-damage": "no-damage buildings",
+        "minor-damage": "minor-damage buildings",
+        "major-damage": "major-damage buildings",
+        "destroyed": "destroyed buildings",
+    }[metric]
+    prompt = f"""
+You are Hazardly, a disaster damage assessment assistant.
+
+Use only these exact facts:
+Ranking metric: {metric_label}
+Top rows: {sort_city_rows(rows, metric)[:limit]}
+
+Write a concise answer for the user.
+
+Rules:
+- Use 3 to 5 short bullet points.
+- Keep the city names and numbers exact.
+- Mention which metric is being ranked.
+- Do not invent extra numbers or places.
+"""
+    return synthesize_structured_answer(prompt, fallback)
+
+
 def format_percentage_response(location_text, damage_type, total, matching_total):
     if total == 0:
         return f"I couldn't find damage assessment data for {location_text}."
@@ -632,6 +659,29 @@ def format_percentage_response(location_text, damage_type, total, matching_total
         f"- Share of total: {percentage}%",
     ]
     return "\n".join(lines)
+
+
+def synthesize_percentage_answer(location_text, damage_type, total, matching_total):
+    fallback = format_percentage_response(location_text, damage_type, total, matching_total)
+    percentage = 0 if total == 0 else round((matching_total / total) * 100, 1)
+    prompt = f"""
+You are Hazardly, a disaster damage assessment assistant.
+
+Use only these exact facts:
+Location: {location_text}
+Damage type: {damage_type}
+Total buildings: {total}
+Matching buildings: {matching_total}
+Percentage: {percentage}
+
+Write a concise answer for the user.
+
+Rules:
+- Use 2 to 4 short bullet points.
+- Keep the counts and percentage exact.
+- Do not invent extra numbers.
+"""
+    return synthesize_structured_answer(prompt, fallback)
 
 
 def format_location_comparison(first_label, first_buildings, second_label, second_buildings):
@@ -665,6 +715,30 @@ def format_location_comparison(first_label, first_buildings, second_label, secon
         worse_line,
     ]
     return "\n".join(lines)
+
+
+def synthesize_location_comparison_answer(first_label, first_buildings, second_label, second_buildings):
+    fallback = format_location_comparison(first_label, first_buildings, second_label, second_buildings)
+    first_counts = count_damage_levels(first_buildings)
+    second_counts = count_damage_levels(second_buildings)
+    prompt = f"""
+You are Hazardly, a disaster damage assessment assistant.
+
+Use only these exact facts:
+First location: {first_label}
+First counts: {first_counts}
+Second location: {second_label}
+Second counts: {second_counts}
+
+Write a concise answer for the user.
+
+Rules:
+- Use 3 to 5 short bullet points.
+- Compare the two locations directly.
+- Keep all counts exact.
+- Do not invent extra numbers or conclusions not supported by the counts.
+"""
+    return synthesize_structured_answer(prompt, fallback)
 
 
 def normalize_street_query_parts(address_text):
@@ -1028,6 +1102,26 @@ def format_damage_bullet_summary(counts, location_text):
     return "\n".join(lines)
 
 
+def synthesize_location_overview_answer(location_text, counts):
+    fallback = format_damage_bullet_summary(counts, location_text)
+    prompt = f"""
+You are Hazardly, a disaster damage assessment assistant.
+
+Use only these exact facts:
+Location: {location_text}
+Counts: {counts}
+
+Write a concise answer for the user.
+
+Rules:
+- Use 3 to 5 short bullet points.
+- Mention the total buildings and the key damage breakdown.
+- Do not invent extra numbers.
+- Do not mention databases, SQL, retrieval, tools, or models.
+"""
+    return synthesize_structured_answer(prompt, fallback)
+
+
 
 
 # function used when there is no frontend navigation action
@@ -1183,6 +1277,15 @@ def call_nemotron(prompt):
         return content if content else None
     except Exception:
         return None
+
+
+def synthesize_structured_answer(prompt, fallback_answer):
+    result = call_nemotron(prompt)
+    if not result:
+        return fallback_answer
+
+    cleaned = str(result).strip().strip('"')
+    return cleaned if cleaned else fallback_answer
 
 
 def fallback_damage_answer(total, address, damage_type):
@@ -1512,6 +1615,25 @@ def format_city_damage_stats(rows):
     return "\n".join(lines)
 
 
+def synthesize_city_damage_stats_answer(rows):
+    fallback = format_city_damage_stats(rows)
+    prompt = f"""
+You are Hazardly, a disaster damage assessment assistant.
+
+Use only these exact facts:
+City rows: {rows[:8]}
+
+Write a concise answer for the user.
+
+Rules:
+- Use 3 to 5 short bullet points.
+- Keep city names and counts exact.
+- Mention that this is a sample of cities in the active dataset.
+- Do not invent extra places or numbers.
+"""
+    return synthesize_structured_answer(prompt, fallback)
+
+
 def summarize_damage_data(buildings, address):
     counts = {}
 
@@ -1617,7 +1739,7 @@ def handle_chat_query(question):
 
     if is_city_list_query(question):
         rows = fetch_city_damage_stats()
-        answer = format_city_damage_stats(rows)
+        answer = synthesize_city_damage_stats_answer(rows)
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -1629,7 +1751,7 @@ def handle_chat_query(question):
 
     if is_city_ranking_query(question):
         rows = fetch_city_damage_stats()
-        answer = format_city_ranking(
+        answer = synthesize_city_ranking_answer(
             rows,
             get_ranking_metric(question),
             extract_top_n(question),
@@ -1649,7 +1771,7 @@ def handle_chat_query(question):
         first_geo, first_label, first_buildings = resolve_location_buildings(first_location)
         second_geo, second_label, second_buildings = resolve_location_buildings(second_location)
 
-        answer = format_location_comparison(
+        answer = synthesize_location_comparison_answer(
             first_label,
             first_buildings,
             second_label,
@@ -1669,7 +1791,7 @@ def handle_chat_query(question):
         _, damage_type = parse_question(question)
         geo, label_text, all_buildings = resolve_location_buildings(percentage_location_text)
         matching_buildings = filter_buildings_by_damage(all_buildings, damage_type)
-        answer = format_percentage_response(
+        answer = synthesize_percentage_answer(
             label_text,
             damage_type,
             len(all_buildings),
@@ -1700,7 +1822,7 @@ def handle_chat_query(question):
             }
 
         counts = count_damage_levels(all_buildings)
-        answer = format_damage_bullet_summary(counts, label_text)
+        answer = synthesize_location_overview_answer(label_text, counts)
 
         save_turn(question, answer)
         return {
@@ -1727,7 +1849,7 @@ def handle_chat_query(question):
     # full dataset summary does not have a single map focus
     if is_full_dataset_query(question):
         counts = get_full_dataset_damage_counts()
-        answer = format_damage_bullet_summary(counts, "the full dataset")
+        answer = synthesize_location_overview_answer("the full dataset", counts)
         save_turn(question, answer)
         return {
             "answer": answer,
@@ -1766,7 +1888,7 @@ def handle_chat_query(question):
         label_text = geo["formatted_address"] if geo else on_location_text
         if wants_all_buildings:
             counts = count_damage_levels(buildings)
-            answer = format_damage_bullet_summary(counts, f"addresses on {label_text}")
+            answer = synthesize_location_overview_answer(f"addresses on {label_text}", counts)
         elif damage_type == "no-damage":
             answer = f"{len(buildings)} buildings on {label_text} appear to have no visible damage."
         else:

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -117,6 +117,7 @@ load_dotenv(BACKEND_DIR / ".env", override=True)
 # frontend route example: /map/hurricane-harvey/3?building=<building_uid>
 # this can be changed later through backend/.env if needed
 DEFAULT_DISASTER_NAME = os.getenv("DEFAULT_DISASTER_NAME", "hurricane-harvey")
+DEFAULT_QUERY_LOCATION = "Houston, Texas"
 STREET_ADDRESS_OVERVIEW_RADIUS_M = 300
 EXACT_ADDRESS_OVERVIEW_RADIUS_M = 75
 NAMED_LOCATION_OVERVIEW_RADIUS_M = 5000
@@ -236,10 +237,10 @@ def parse_question(question):
 
         # fix vague location like "me"
         if address in ["me", "here", "my", "", "?"]:
-            address = "Houston Texas"
+            address = DEFAULT_QUERY_LOCATION
 
     else:
-        address = None
+        address = DEFAULT_QUERY_LOCATION
 
     if address is not None and not str(address).strip():
         address = None
@@ -2351,6 +2352,10 @@ def is_full_dataset_query(question):
         "what is this dataset",
         "what data is this",
         "what dataset is this",
+        "what does the dataset contain",
+        "what does this dataset contain",
+        "what does the data contain",
+        "what does this data contain",
         "what does the data show",
         "tell me about the data",
         "tell me about the dataset",
@@ -3070,7 +3075,7 @@ def parse_structured_query(question):
     else:
         primary_location = (
             normalize_location_candidate(parsed_address)
-            if explicit_near_or_in_match
+            if explicit_near_or_in_match or mapped_intent == "location_query"
             else None
         )
         locations = [primary_location] if primary_location else []

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -411,6 +411,37 @@ def get_all_buildings_in_bbox(min_lon, min_lat, max_lon, max_lat):
     return rows_to_buildings(rows)
 
 
+def fetch_city_damage_stats(limit=20):
+    conn = get_db_connection()
+    cur = conn.cursor()
+
+    query = """
+    SELECT
+      TRIM(SPLIT_PART(b.address, ',', 2)) AS city,
+      COUNT(*) AS total,
+      SUM(CASE WHEN b.predicted_damage = 'no-damage' THEN 1 ELSE 0 END) AS no_damage,
+      SUM(CASE WHEN b.predicted_damage = 'minor-damage' THEN 1 ELSE 0 END) AS minor_damage,
+      SUM(CASE WHEN b.predicted_damage = 'major-damage' THEN 1 ELSE 0 END) AS major_damage,
+      SUM(CASE WHEN b.predicted_damage = 'destroyed' THEN 1 ELSE 0 END) AS destroyed
+    FROM buildings b
+    WHERE b.address IS NOT NULL
+      AND POSITION(',' IN b.address) > 0
+      AND POSITION(',' IN SUBSTRING(b.address FROM POSITION(',' IN b.address) + 1)) > 0
+    GROUP BY TRIM(SPLIT_PART(b.address, ',', 2))
+    HAVING TRIM(SPLIT_PART(b.address, ',', 2)) <> ''
+    ORDER BY total DESC, city ASC
+    LIMIT %s
+    """
+
+    cur.execute(query, (limit,))
+    rows = cur.fetchall()
+
+    cur.close()
+    conn.close()
+
+    return rows
+
+
 def get_buildings_by_address_text(address_text, damage_filter):
     conn = get_db_connection()
     cur = conn.cursor()
@@ -950,6 +981,38 @@ def is_conversation_summary_query(question):
         
     ])
 
+
+def is_city_list_query(question):
+    q = question.lower()
+    return any(k in q for k in [
+        "what cities are in the dataset",
+        "which cities are in the dataset",
+        "what cities are affected",
+        "which cities were affected",
+        "what cities were affected",
+        "which cities are affected",
+        "list the affected cities",
+        "list cities in the dataset",
+        "what locations are in the dataset",
+    ])
+
+
+def format_city_damage_stats(rows):
+    if len(rows) == 0:
+        return "I couldn’t find any city-level address data in the dataset."
+
+    summary_parts = []
+    for row in rows[:8]:
+        city = row[0]
+        total = row[1]
+        destroyed = row[5]
+        major = row[4]
+        summary_parts.append(
+            f"{city} ({total} total, {major} major-damage, {destroyed} destroyed)"
+        )
+
+    return "Cities in the dataset include: " + "; ".join(summary_parts) + "."
+
 def summarize_damage_data(buildings, address):
 
     counts = {}
@@ -1054,6 +1117,18 @@ def handle_chat_query(question):
             "focus": None,
             "highlighted_buildings": [],
             "action": build_no_action()  # no navigation action
+        }
+
+    if is_city_list_query(question):
+        rows = fetch_city_damage_stats()
+        answer = format_city_damage_stats(rows)
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
         }
 
     general_location_text = extract_general_location_text(question)

--- a/backend/app/rag_agent.py
+++ b/backend/app/rag_agent.py
@@ -165,6 +165,31 @@ def extract_in_location_text(question):
     return address_text or None
 
 
+def extract_general_location_text(question):
+    patterns = [
+        r"tell me about\s+(.+?)(?:\?|$)",
+        r"what about\s+(.+?)(?:\?|$)",
+        r"give me stats for\s+(.+?)(?:\?|$)",
+        r"give me information about\s+(.+?)(?:\?|$)",
+        r"overview of\s+(.+?)(?:\?|$)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, question, flags=re.IGNORECASE)
+        if not match:
+            continue
+        location_text = match.group(1).strip(" ?,.")
+        location_text = re.sub(
+            r"\b(damage|damaged|buildings?|properties|records|stats|statistics|information)\b",
+            "",
+            location_text,
+            flags=re.IGNORECASE,
+        ).strip(" ,")
+        return location_text or None
+
+    return None
+
+
 
 
 # function to convert address → latitude/longitude using Mapbox API
@@ -1029,6 +1054,46 @@ def handle_chat_query(question):
             "focus": None,
             "highlighted_buildings": [],
             "action": build_no_action()  # no navigation action
+        }
+
+    general_location_text = extract_general_location_text(question)
+    if general_location_text:
+        geo = geocode_address(general_location_text)
+        all_buildings = []
+        if geo and geo.get("bbox") and len(geo["bbox"]) == 4:
+            min_lon, min_lat, max_lon, max_lat = geo["bbox"]
+            all_buildings = get_all_buildings_in_bbox(
+                min_lon,
+                min_lat,
+                max_lon,
+                max_lat,
+            )
+        if len(all_buildings) == 0:
+            all_buildings = get_all_buildings_by_address_text(general_location_text)
+
+        if len(all_buildings) == 0:
+            answer = f"I could not find relevant damage data for {general_location_text}."
+            save_turn(question, answer)
+            return {
+                "answer": answer,
+                "response": answer,
+                "focus": None,
+                "highlighted_buildings": [],
+                "action": build_no_action(),
+            }
+
+        primary_xbd_id = get_primary_xbd_id(all_buildings)
+        label_text = geo["formatted_address"] if geo else general_location_text
+        counts = count_damage_levels(all_buildings)
+        answer = format_damage_count_response(counts, label_text)
+
+        save_turn(question, answer)
+        return {
+            "answer": answer,
+            "response": answer,
+            "focus": None,
+            "highlighted_buildings": [],
+            "action": build_no_action(),
         }
 
     # block non-disaster queries

--- a/backend/app/rag_location_mvp.py
+++ b/backend/app/rag_location_mvp.py
@@ -5,6 +5,7 @@ Minimal RAG plus tool-calling demo for spatial damage queries.
 
 Setup:
 - backend/.env must define:
+  - SUPABASE_URL, SUPABASE_SERVICE_KEY
   - DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME
   - MAPBOX_API_KEY
   - NEMOTRON_URL
@@ -18,6 +19,11 @@ Example output shape:
     Question: Show predicted major damage near 123 Main St
     Parsed address: 123 Main St
     Parsed damage filter: major-damage
+
+    Dataset Snapshot:
+      - disasters: ...
+      - image_pairs: ...
+      - buildings: ...
 
     Tool Trace:
     1. geocode_address(address='123 Main St')
@@ -56,7 +62,17 @@ from llama_index.core.llms import CompletionResponse, CustomLLM
 from llama_index.core.tools import FunctionTool
 from psycopg.rows import dict_row
 
-from app.config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER, db_settings_configured, missing_db_settings
+from app.config import (
+    DB_HOST,
+    DB_NAME,
+    DB_PASSWORD,
+    DB_PORT,
+    DB_USER,
+    SUPABASE_SERVICE_KEY,
+    SUPABASE_URL,
+    db_settings_configured,
+    missing_db_settings,
+)
 
 
 DEFAULT_MODEL = "mistralai/mistral-nemotron"
@@ -69,6 +85,13 @@ class ToolTraceEntry:
     name: str
     arguments: dict[str, Any]
     preview: str
+
+
+@dataclass
+class DatasetSnapshot:
+    disasters: int
+    image_pairs: int
+    buildings: int
 
 
 TRACE_LOG: list[ToolTraceEntry] = []
@@ -94,6 +117,27 @@ def ensure_db_configured() -> None:
     raise RuntimeError(f"Database configuration is incomplete. Missing: {missing}")
 
 
+def ensure_runtime_configured() -> None:
+    ensure_db_configured()
+
+    missing: list[str] = []
+    if not SUPABASE_URL:
+        missing.append("SUPABASE_URL")
+    if not SUPABASE_SERVICE_KEY:
+        missing.append("SUPABASE_SERVICE_KEY")
+    if not os.getenv("MAPBOX_API_KEY"):
+        missing.append("MAPBOX_API_KEY")
+    if not os.getenv("NEMOTRON_URL"):
+        missing.append("NEMOTRON_URL")
+    if not os.getenv("NEMOTRON_API_KEY"):
+        missing.append("NEMOTRON_API_KEY")
+
+    if missing:
+        raise RuntimeError(
+            "Runtime configuration is incomplete. Missing: " + ", ".join(missing)
+        )
+
+
 def get_db_connection() -> psycopg.Connection:
     ensure_db_configured()
     return psycopg.connect(
@@ -103,6 +147,32 @@ def get_db_connection() -> psycopg.Connection:
         password=DB_PASSWORD,
         dbname=DB_NAME,
         row_factory=dict_row,
+    )
+
+
+def fetch_dataset_snapshot() -> DatasetSnapshot:
+    sql = """
+    SELECT
+      COUNT(DISTINCT d.id) AS disasters,
+      COUNT(DISTINCT ip.id) AS image_pairs,
+      COUNT(DISTINCT b.uid) AS buildings
+    FROM disasters d
+    JOIN image_pairs ip ON ip.disaster_id = d.id
+    JOIN buildings b ON b.image_pair_id = ip.id
+    """
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            row = cur.fetchone()
+
+    if not row:
+        return DatasetSnapshot(disasters=0, image_pairs=0, buildings=0)
+
+    return DatasetSnapshot(
+        disasters=int(row["disasters"] or 0),
+        image_pairs=int(row["image_pairs"] or 0),
+        buildings=int(row["buildings"] or 0),
     )
 
 
@@ -292,6 +362,7 @@ def build_retrieval_documents(
     buildings: list[dict[str, Any]],
     damage_filter: str | None,
     radius_m: int,
+    dataset_snapshot: DatasetSnapshot,
 ) -> list[Document]:
     unique_disasters = sorted({str(row["disaster_name"]) for row in buildings})
     intro_lines = [
@@ -299,6 +370,9 @@ def build_retrieval_documents(
         f"Resolved address: {resolved_address}",
         f"Spatial radius meters: {radius_m}",
         f"Requested predicted damage filter: {damage_filter or 'none'}",
+        f"Dataset disaster count: {dataset_snapshot.disasters}",
+        f"Dataset image pair count: {dataset_snapshot.image_pairs}",
+        f"Dataset building count: {dataset_snapshot.buildings}",
         f"Matching buildings returned: {len(buildings)}",
         f"Disasters represented in evidence: {', '.join(unique_disasters) if unique_disasters else 'none'}",
     ]
@@ -339,6 +413,7 @@ def build_rag_answer(
     buildings: list[dict[str, Any]],
     damage_filter: str | None,
     radius_m: int,
+    dataset_snapshot: DatasetSnapshot,
 ) -> str:
     documents = build_retrieval_documents(
         question=question,
@@ -346,6 +421,7 @@ def build_rag_answer(
         buildings=buildings,
         damage_filter=damage_filter,
         radius_m=radius_m,
+        dataset_snapshot=dataset_snapshot,
     )
     index = SummaryIndex.from_documents(documents)
     query_engine = index.as_query_engine(llm=llm, response_mode="compact")
@@ -447,11 +523,20 @@ def print_evidence(buildings: list[dict[str, Any]]) -> None:
         )
 
 
+def print_dataset_snapshot(snapshot: DatasetSnapshot) -> None:
+    print("\nDataset Snapshot:")
+    print(f"  - disasters: {snapshot.disasters}")
+    print(f"  - image_pairs: {snapshot.image_pairs}")
+    print(f"  - buildings: {snapshot.buildings}")
+
+
 def run_demo(question: str, radius_m: int, limit: int) -> None:
     reset_trace()
+    ensure_runtime_configured()
     address, damage_filter = parse_location_query(question)
     llm = NemotronLLM()
     agent = create_agent(llm=llm, radius_m=radius_m, limit=limit)
+    dataset_snapshot = fetch_dataset_snapshot()
 
     print(f"Question: {question}")
     print(f"Parsed address: {address}")
@@ -472,8 +557,10 @@ def run_demo(question: str, radius_m: int, limit: int) -> None:
         buildings=buildings,
         damage_filter=damage_filter,
         radius_m=radius_m,
+        dataset_snapshot=dataset_snapshot,
     )
 
+    print_dataset_snapshot(dataset_snapshot)
     print_tool_trace()
     print_evidence(buildings)
     print("\nAgent Answer:")

--- a/backend/app/rag_location_mvp.py
+++ b/backend/app/rag_location_mvp.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+"""
+Minimal RAG plus tool-calling demo for spatial damage queries.
+
+Setup:
+- backend/.env must define:
+  - DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME
+  - MAPBOX_API_KEY
+  - NEMOTRON_URL
+  - NEMOTRON_API_KEY
+
+Run from the repo root:
+    backend\\.venv\\Scripts\\python.exe -m app.rag_location_mvp ^
+      --question "Show predicted major damage near 123 Main St"
+
+Example output shape:
+    Question: Show predicted major damage near 123 Main St
+    Parsed address: 123 Main St
+    Parsed damage filter: major-damage
+
+    Tool Trace:
+    1. geocode_address(address='123 Main St')
+       -> {'formatted_address': '...', 'lon': ..., 'lat': ...}
+    2. get_buildings_near(lon=..., lat=..., radius_m=5000, damage_filter='major-damage')
+       -> 7 rows
+
+    Evidence:
+    - uid=... xbd_id=... disaster=hurricane-harvey damage=major-damage distance_m=...
+
+    Agent Answer:
+    ...
+
+    RAG Answer:
+    ...
+
+Validation notes:
+- This script is intentionally narrow. It validates one location-query flow.
+- It will raise if the agent does not call both required tools in order:
+  1. geocode_address(...)
+  2. get_buildings_near(...)
+"""
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+import requests
+from llama_index.core import Document, SummaryIndex
+from llama_index.core.agent import ReActAgent
+from llama_index.core.llms import CompletionResponse, CustomLLM
+from llama_index.core.tools import FunctionTool
+from psycopg.rows import dict_row
+
+from app.config import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER, db_settings_configured, missing_db_settings
+
+
+DEFAULT_MODEL = "mistralai/mistral-nemotron"
+DEFAULT_RADIUS_M = 5000
+DEFAULT_LIMIT = 25
+
+
+@dataclass
+class ToolTraceEntry:
+    name: str
+    arguments: dict[str, Any]
+    preview: str
+
+
+TRACE_LOG: list[ToolTraceEntry] = []
+LAST_GEOCODE_RESULT: dict[str, Any] | None = None
+LAST_BUILDING_RESULTS: list[dict[str, Any]] = []
+
+
+def reset_trace() -> None:
+    TRACE_LOG.clear()
+    global LAST_GEOCODE_RESULT, LAST_BUILDING_RESULTS
+    LAST_GEOCODE_RESULT = None
+    LAST_BUILDING_RESULTS = []
+
+
+def record_tool_call(name: str, arguments: dict[str, Any], preview: str) -> None:
+    TRACE_LOG.append(ToolTraceEntry(name=name, arguments=arguments, preview=preview))
+
+
+def ensure_db_configured() -> None:
+    if db_settings_configured():
+        return
+    missing = ", ".join(missing_db_settings())
+    raise RuntimeError(f"Database configuration is incomplete. Missing: {missing}")
+
+
+def get_db_connection() -> psycopg.Connection:
+    ensure_db_configured()
+    return psycopg.connect(
+        host=DB_HOST,
+        port=int(DB_PORT),
+        user=DB_USER,
+        password=DB_PASSWORD,
+        dbname=DB_NAME,
+        row_factory=dict_row,
+    )
+
+
+def call_nemotron(prompt: str) -> str:
+    url = os.getenv("NEMOTRON_URL")
+    api_key = os.getenv("NEMOTRON_API_KEY")
+
+    if not url or not api_key:
+        raise RuntimeError("Nemotron configuration is incomplete. Set NEMOTRON_URL and NEMOTRON_API_KEY.")
+
+    response = requests.post(
+        url,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": DEFAULT_MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 300,
+        },
+        timeout=30,
+    )
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Nemotron request failed: {response.status_code} {response.text}")
+
+    data = response.json()
+    content = data["choices"][0]["message"]["content"].strip().strip('"')
+    if not content:
+        raise RuntimeError("Nemotron returned an empty completion.")
+    return content
+
+
+class NemotronLLM(CustomLLM):
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "context_window": 4096,
+            "num_output": 256,
+            "model_name": "nemotron",
+        }
+
+    def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        return CompletionResponse(text=call_nemotron(prompt))
+
+    def stream_complete(self, prompt: str, **kwargs: Any):
+        yield CompletionResponse(text=self.complete(prompt, **kwargs).text)
+
+
+def parse_location_query(question: str) -> tuple[str, str | None]:
+    q = question.lower()
+    damage_filter = None
+    if "destroyed" in q:
+        damage_filter = "destroyed"
+    elif "major" in q:
+        damage_filter = "major-damage"
+    elif "minor" in q:
+        damage_filter = "minor-damage"
+    elif any(token in q for token in ["no damage", "no-damage", "undamaged"]):
+        damage_filter = "no-damage"
+
+    match = re.search(r"\bnear\s+(.+?)(?:\?|$)", question, flags=re.IGNORECASE)
+    if not match:
+        raise ValueError("This MVP expects a location query containing 'near <address>'.")
+
+    address = match.group(1).strip(" ?,.")
+    if not address:
+        raise ValueError("Could not parse an address from the question.")
+
+    return address, damage_filter
+
+
+def geocode_address(address: str) -> dict[str, Any]:
+    api_key = os.getenv("MAPBOX_API_KEY")
+    if not api_key:
+        raise RuntimeError("MAPBOX_API_KEY is not configured.")
+
+    response = requests.get(
+        f"https://api.mapbox.com/geocoding/v5/mapbox.places/{address}.json",
+        params={"access_token": api_key, "limit": 1},
+        timeout=20,
+    )
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Mapbox geocoding failed: {response.status_code} {response.text}")
+
+    data = response.json()
+    if not data.get("features"):
+        raise RuntimeError(f"Mapbox returned no result for address: {address}")
+
+    feature = data["features"][0]
+    result = {
+        "formatted_address": feature["place_name"],
+        "lon": feature["center"][0],
+        "lat": feature["center"][1],
+        "bbox": feature.get("bbox"),
+    }
+
+    global LAST_GEOCODE_RESULT
+    LAST_GEOCODE_RESULT = result
+    record_tool_call("geocode_address", {"address": address}, json.dumps(result, default=str))
+    return result
+
+
+def get_buildings_near(
+    lon: float,
+    lat: float,
+    radius_m: int = DEFAULT_RADIUS_M,
+    damage_filter: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> list[dict[str, Any]]:
+    sql = """
+    SELECT
+      b.uid,
+      b.predicted_damage,
+      ST_AsGeoJSON(b.geom) AS geom_geojson,
+      ip.id AS image_pair_id,
+      ip.xbd_id,
+      ip.capture_date,
+      ip.sensor,
+      d.id AS disaster_id,
+      d.name AS disaster_name,
+      d.type AS disaster_type,
+      ROUND(
+        CAST(
+          ST_Distance(
+            b.geom::geography,
+            ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography
+          ) AS numeric
+        ),
+        2
+      ) AS distance_m
+    FROM buildings b
+    JOIN image_pairs ip ON b.image_pair_id = ip.id
+    JOIN disasters d ON ip.disaster_id = d.id
+    WHERE ST_DWithin(
+      b.geom::geography,
+      ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
+      %s
+    )
+    """
+
+    params: list[Any] = [lon, lat, lon, lat, radius_m]
+    if damage_filter:
+        sql += " AND b.predicted_damage = %s"
+        params.append(damage_filter)
+
+    sql += " ORDER BY distance_m ASC LIMIT %s"
+    params.append(limit)
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, tuple(params))
+            rows = cur.fetchall()
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        result = dict(row)
+        geom_geojson = result.get("geom_geojson")
+        if isinstance(geom_geojson, str):
+            result["geometry"] = json.loads(geom_geojson)
+        else:
+            result["geometry"] = geom_geojson
+        result.pop("geom_geojson", None)
+        results.append(result)
+
+    global LAST_BUILDING_RESULTS
+    LAST_BUILDING_RESULTS = results
+    record_tool_call(
+        "get_buildings_near",
+        {
+            "lon": lon,
+            "lat": lat,
+            "radius_m": radius_m,
+            "damage_filter": damage_filter,
+            "limit": limit,
+        },
+        f"{len(results)} rows",
+    )
+    return results
+
+
+def build_retrieval_documents(
+    question: str,
+    resolved_address: str,
+    buildings: list[dict[str, Any]],
+    damage_filter: str | None,
+    radius_m: int,
+) -> list[Document]:
+    unique_disasters = sorted({str(row["disaster_name"]) for row in buildings})
+    intro_lines = [
+        f"User question: {question}",
+        f"Resolved address: {resolved_address}",
+        f"Spatial radius meters: {radius_m}",
+        f"Requested predicted damage filter: {damage_filter or 'none'}",
+        f"Matching buildings returned: {len(buildings)}",
+        f"Disasters represented in evidence: {', '.join(unique_disasters) if unique_disasters else 'none'}",
+    ]
+
+    documents = [Document(text="\n".join(intro_lines))]
+
+    for row in buildings[:10]:
+        documents.append(
+            Document(
+                text="\n".join(
+                    [
+                        f"Building UID: {row['uid']}",
+                        f"Predicted damage: {row['predicted_damage']}",
+                        f"Distance meters: {row['distance_m']}",
+                        f"Disaster: {row['disaster_name']} ({row['disaster_type']})",
+                        f"Image pair ID: {row['image_pair_id']}",
+                        f"xBD ID: {row['xbd_id']}",
+                        f"Capture date: {row['capture_date']}",
+                        f"Sensor: {row['sensor']}",
+                    ]
+                ),
+                metadata={
+                    "uid": str(row["uid"]),
+                    "xbd_id": row["xbd_id"],
+                    "disaster_name": row["disaster_name"],
+                    "predicted_damage": row["predicted_damage"],
+                },
+            )
+        )
+
+    return documents
+
+
+def build_rag_answer(
+    llm: NemotronLLM,
+    question: str,
+    resolved_address: str,
+    buildings: list[dict[str, Any]],
+    damage_filter: str | None,
+    radius_m: int,
+) -> str:
+    documents = build_retrieval_documents(
+        question=question,
+        resolved_address=resolved_address,
+        buildings=buildings,
+        damage_filter=damage_filter,
+        radius_m=radius_m,
+    )
+    index = SummaryIndex.from_documents(documents)
+    query_engine = index.as_query_engine(llm=llm, response_mode="compact")
+    prompt = f"""
+Use only the retrieved evidence to answer the user's question.
+
+User question: {question}
+Resolved address: {resolved_address}
+Requested damage filter: {damage_filter or "none"}
+
+Requirements:
+- State how many matching buildings were found.
+- Mention the damage filter if one was requested.
+- Mention up to three building UIDs from the evidence.
+- Do not invent IDs, counts, or locations.
+- Keep the answer concise.
+"""
+    return str(query_engine.query(prompt))
+
+
+def create_agent(llm: NemotronLLM, radius_m: int, limit: int) -> ReActAgent:
+    geocode_tool = FunctionTool.from_defaults(
+        fn=geocode_address,
+        name="geocode_address",
+        description="Resolve a user-provided address into longitude, latitude, and a formatted address using Mapbox.",
+    )
+    buildings_tool = FunctionTool.from_defaults(
+        fn=get_buildings_near,
+        name="get_buildings_near",
+        description=(
+            "Query PostGIS for buildings near a lon/lat point. "
+            "Use radius_m in meters and predicted damage labels like major-damage."
+        ),
+    )
+
+    system_prompt = f"""
+You are an aerial damage assessment agent.
+
+For location-based questions:
+1. Call geocode_address first.
+2. Then call get_buildings_near using the geocoded lon/lat.
+3. Use radius_m={radius_m} unless the user specifies another radius.
+4. If the user asks for predicted major damage, use damage_filter="major-damage".
+5. Do not invent tool outputs.
+6. Keep the final answer short and factual.
+
+The SQL tool already handles spatial filtering and optional predicted_damage filtering.
+Tool result limit is {limit}.
+"""
+    return ReActAgent.from_tools(
+        [geocode_tool, buildings_tool],
+        llm=llm,
+        verbose=True,
+        system_prompt=system_prompt,
+    )
+
+
+def print_tool_trace() -> None:
+    print("\nTool Trace:")
+    if not TRACE_LOG:
+        print("  (no tool calls recorded)")
+        return
+
+    for index, entry in enumerate(TRACE_LOG, start=1):
+        rendered_args = ", ".join(f"{key}={value!r}" for key, value in entry.arguments.items())
+        print(f"{index}. {entry.name}({rendered_args})")
+        print(f"   -> {entry.preview}")
+
+
+def validate_required_tool_flow() -> None:
+    tool_names = [entry.name for entry in TRACE_LOG]
+    expected = ["geocode_address", "get_buildings_near"]
+
+    if len(tool_names) < 2:
+        raise RuntimeError(
+            f"Expected tool flow {expected}, but recorded only {tool_names}."
+        )
+
+    if tool_names[:2] != expected:
+        raise RuntimeError(
+            f"Expected first tool calls {expected}, but recorded {tool_names[:2]}."
+        )
+
+
+def print_evidence(buildings: list[dict[str, Any]]) -> None:
+    print("\nEvidence:")
+    if not buildings:
+        print("  (no buildings found)")
+        return
+
+    for row in buildings[:10]:
+        print(
+            "  - "
+            f"uid={row['uid']} "
+            f"xbd_id={row['xbd_id']} "
+            f"disaster={row['disaster_name']} "
+            f"damage={row['predicted_damage']} "
+            f"distance_m={row['distance_m']}"
+        )
+
+
+def run_demo(question: str, radius_m: int, limit: int) -> None:
+    reset_trace()
+    address, damage_filter = parse_location_query(question)
+    llm = NemotronLLM()
+    agent = create_agent(llm=llm, radius_m=radius_m, limit=limit)
+
+    print(f"Question: {question}")
+    print(f"Parsed address: {address}")
+    print(f"Parsed damage filter: {damage_filter or 'none'}")
+
+    agent_response = str(agent.chat(question))
+    geocode_result = LAST_GEOCODE_RESULT
+    buildings = LAST_BUILDING_RESULTS
+    validate_required_tool_flow()
+
+    if not geocode_result:
+        raise RuntimeError("The agent did not record a geocode result.")
+
+    rag_answer = build_rag_answer(
+        llm=llm,
+        question=question,
+        resolved_address=geocode_result["formatted_address"],
+        buildings=buildings,
+        damage_filter=damage_filter,
+        radius_m=radius_m,
+    )
+
+    print_tool_trace()
+    print_evidence(buildings)
+    print("\nAgent Answer:")
+    print(agent_response)
+    print("\nRAG Answer:")
+    print(rag_answer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the RAG plus tool-calling location-query MVP.")
+    parser.add_argument(
+        "--question",
+        default="Show predicted major damage near 123 Main St",
+        help="Natural-language query to execute.",
+    )
+    parser.add_argument(
+        "--radius-m",
+        type=int,
+        default=DEFAULT_RADIUS_M,
+        help="Spatial search radius in meters for the PostGIS query.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="Maximum number of building rows to retrieve.",
+    )
+    args = parser.parse_args()
+    run_demo(question=args.question, radius_m=args.radius_m, limit=args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.rag_agent import handle_chat_query
+
+router = APIRouter()
+
+
+class ChatRequest(BaseModel):
+    question: str
+
+
+@router.post("/chat")
+def chat(request: ChatRequest):
+    return handle_chat_query(request.question)

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -8,8 +8,9 @@ router = APIRouter()
 
 class ChatRequest(BaseModel):
     question: str
+    session_id: str | None = None
 
 
 @router.post("/chat")
 def chat(request: ChatRequest):
-    return handle_chat_query(request.question)
+    return handle_chat_query(request.question, request.session_id)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ psycopg[binary]>=3.2
 python-dotenv>=1.0
 supabase>=2.0
 numpy>=1.26
+llama-index-core

--- a/backend/resources/disaster_guidance/ready_gov_floods.md
+++ b/backend/resources/disaster_guidance/ready_gov_floods.md
@@ -1,0 +1,88 @@
+# Flood Safety Guidance
+
+Source: Ready.gov, "Floods"
+URL: https://www.ready.gov/floods
+
+Floods
+======
+
+Flooding is a temporary overflow of water on land that is normally dry. Floods are the most common disaster in the United States. Failing to evacuate flooded areas or entering floodwaters can lead to injury or death.
+
+Floods may:
+
+*   Result from rain, snow, coastal storms, storm surges and overflows of dams and other water systems.
+*   Develop slowly or quickly. Flash floods can come without warning.
+*   Cause outages, disrupt transportation, damage buildings and create landslides.
+
+**If you are under a flood warning**
+------------------------------------
+
+*   Find safe shelter right away.
+*   Do not walk, swim or drive through floodwaters**. Turn Around, Don’t Drown!**
+*   Remember, just six inches of moving water can knock you down, and one foot of moving water can sweep your vehicle away.
+*   Stay off bridges over fast-moving water.
+*   Depending on the type of flooding:
+    *   Evacuate if told to do so.
+    *   Move to higher ground or a higher floor.
+    *   Stay where you are.
+
+**Before a Flood**
+------------------
+
+*   **Know your risk for floods**, [visit FEMA's Flood Map Service Center](https://msc.fema.gov/portal) to know types of flood risks in your area. However, remember that flooding doesn’t follow lines on a map.
+*   Where it rains it can flood. Sign up for your community’s warning system. The [Emergency Alert System (EAS)](https://www.fema.gov/emergency-alert-system) and [National Oceanic and Atmospheric Administration (NOAA)](https://www.noaa.gov/) 
+*   Weather Radio also provide emergency alerts. The [National Risk Index](https://www.fema.gov/flood-maps/products-tools/national-risk-index)
+*   **Purchase flood insurance or renew** a flood insurance policy. Homeowner’s insurance policies do not cover flooding. It typically takes up to 30 days for a policy to go into effect, so the time to buy is well before a disaster. [Get flood coverage under the National Flood Insurance Program (NFIP)](https://www.fema.gov/national-flood-insurance-program).
+*   **Preparing for a Flood** - [Make a plan](https://www.ready.gov/plan) for your household, including [your pets](https://www.ready.gov/pets) so that you and your family know what to do, where to go and what you will need to protect yourselves from flooding.
+    *   Learn and practice evacuation routes, shelter plans and flash flood response.
+    *   Gather supplies, including non-perishable foods, cleaning supplies and water for several days, in case you must leave immediately or if services are cut off in your area.
+*   In case of emergency, keep documents in a waterproof container.
+    *   Create password-protected digital copies. Protect your property.
+    *   Move valuables to higher levels.
+    *   Declutter drains and gutters.
+    *   Install check valves. Consider a sump pump with a battery.
+
+**During a Flood**
+------------------
+
+*   Evacuate immediately, if told to do so. Never drive around barricades. Local responders use them to safely direct traffic out of flooded areas.
+*   Contact your healthcare provider if you are sick and need medical attention. Wait for further care instructions and shelter in place, if possible. If you are experiencing a medical emergency, call 9-1-1.
+*   Listen to EAS, NOAA Weather Radio or local alerting systems for current emergency information and instructions regarding flooding.
+*   Do not walk, swim or drive through floodwaters. **Turn Around. Don’t Drown!**
+*   Stay off bridges over fast-moving water. Fast-moving water can wash bridges away without warning.
+*   Stay inside your car if it is trapped in rapidly moving water. Get on the roof if water is rising inside the car.
+*   Get to the highest level if trapped in a building. Only get on the roof if necessary and once there, signal for help. Do not climb into a closed attic to avoid getting trapped by rising floodwater.
+
+**After a Flood**
+-----------------
+
+*   Pay attention to authorities for information and instructions. Return home only when authorities say it is safe.
+*   Avoid driving except in emergencies.
+*   Wear heavy work gloves, protective clothing and boots during cleanup and use appropriate face coverings or masks if cleaning [mold or other debris.](https://www.cdc.gov/mold-health/communication-resources/guide-to-mold-cleanup.html) 
+*   People with [asthma and other lung conditions and/or immune suppression](https://www.cdc.gov/natural-disasters/communication-resources/asthma-care-before-during-and-after-a-hurricane-or-other-tropical-storm-factsheet.html) should not enter buildings with indoor water leaks or mold growth that can be seen or smelled. Children should not take part in disaster cleanup work.
+*   Be aware that snakes and other animals may be in your house.
+*   Be aware of the risk of electrocution. Do not touch electrical equipment if it is wet or if you are standing in water. Turn off the electricity to prevent electric shock if it is safe to do so.
+*   Avoid wading in floodwater, which can be contaminated and contain dangerous debris. Underground or downed power lines can electrically charge the water.
+*   Use a generator or other gasoline-powered machinery ONLY outdoors and away from windows.
+
+**Additional Resources**
+------------------------
+
+*   [Flood Information Sheet](https://www.ready.gov/sites/default/files/2025-01/fema_flood-hazard-info-sheet.pdf) (PDF)
+*   [Flood Safety Graphics](https://www.ready.gov/collection/flood-safety)
+*   [Flood Safety Social Media Toolkit](https://www.ready.gov/flood-toolkit)
+*   [National Flood Insurance Program (NFIP)](https://www.floodsmart.gov/)
+*   [NFIP Spring Flooding Disaster Social Media Messaging](https://www.ready.gov/sites/default/files/2026-02/nfip_spring-flooding_disaster-social-media-toolkit.pdf)
+*   [Flood Insurance Claims Checklist](https://www.ready.gov/sites/default/files/2026-01/ready-gov_flood-insurance-claims-checklist.pdf)
+*   [National Weather Service Weather Ready Nation Spring Safety Outreach Materials](https://www.weather.gov/wrn/spring2017-flood-sm)
+*   [Flood Insurance Facts](https://www.fema.gov/national-flood-insurance-program)
+*   [Six Things to Know Before a Disaster](https://www.youtube.com/watch?v=0zCl5MuiOu4) (Video)
+*   [When the Cloud Forms](https://youtu.be/LmCnXWN0Dwc) (Video)
+*   [File A Flood Insurance Claim](https://www.floodsmart.gov/recover/start-a-claim)
+*   [Your Homeowners Insurance Does Not Cover Flood](https://www.ready.gov/collection/homeowners-floods) (PDF)
+
+### Partner Resources
+
+*   [American Red Cross](http://www.redcross.org/get-help/how-to-prepare-for-emergencies/types-of-emergencies/flood.html)
+
+If you are a disaster survivor, please visit [FEMA.gov](http://www.fema.gov) for up-to-date information on current disaster declarations.

--- a/backend/resources/disaster_guidance/ready_gov_hurricanes.md
+++ b/backend/resources/disaster_guidance/ready_gov_hurricanes.md
@@ -1,0 +1,85 @@
+# Hurricane Safety Guidance
+
+Source: Ready.gov, "Hurricanes"
+URL: https://www.ready.gov/hurricanes
+
+Hurricanes
+==========
+
+Hurricanes are dangerous and can cause major damage from storm surges, wind damage, rip currents and flooding. They can happen along any U.S. coast or in any territory in the Atlantic or Pacific oceans. Historically, storm surge is the leading cause of hurricane-related deaths in the United States. In parts of the western North Pacific, hurricanes are called typhoons.
+
+**Eastern Pacific Hurricane Season:** May 15-November 30.
+
+**Atlantic Hurricane Season:** June 1-November 30.
+
+**Central Pacific Typhoon** **Season:** June 1-November 30.
+
+Before a Hurricane/Typhoon
+--------------------------
+
+*   **Know Your Hurricane Risk**
+    *   Hurricanes are not just a coastal problem. Find out how rain, wind, water and even tornadoes could happen far inland from where a hurricane or tropical storm makes landfall. [Start preparing now](https://www.ready.gov/sites/default/files/2024-07/ready.gov_hurricane_info-sheet.pdf).
+*   **Make an Emergency Plan**
+    *   Make sure everyone in your household knows and understands [your hurricane plans](https://www.ready.gov/plan).
+    *   Identify whether you may need additional help during an emergency if you or anyone else in your household is an [individual with a disability.](https://www.ready.gov/people-disabilities)
+    *   Ensure your business has a [continuity plan](https://www.ready.gov/business) to continue operating when disaster strikes.
+*   **Know your Evacuation Zone**
+    *   You may have to evacuate quickly due to a hurricane if you live in an evacuation zone. [Learn your evacuation routes](https://www.ready.gov/evacuation), practice with your household and pets, and identify where you will stay. 
+    *   Follow the instructions from local emergency managers, who work closely with state, local, tribal and territorial agencies and partners. They will provide the latest recommendations based on the threat to your community and issue safety measures.
+*   **Recognize Warnings and Alerts**
+    *   Be sure to have several ways to receive alerts. [Download the FEMA app](https://www.fema.gov/mobile-app) and receive real-time alerts from the National Weather Service for up to five locations nationwide. 
+    *   [Sign up for community alerts](https://www.ready.gov/alerts) in your area and be aware of the Emergency Alert System (EAS) and Wireless Emergency Alert (WEA), which require no sign up.
+*   **Review Important Documents**
+    *   Make sure your [insurance policies and personal documents](https://www.ready.gov/financial-preparedness), such as ID, are up to date. Make copies and keep them in a secure password-protected digital space.
+*   **Strengthen your Home**
+    *   De-clutter drains and gutters, bring in outside furniture and consider hurricane shutters.
+*   **Get Tech Ready**
+    *   [Keep your cell phone charged](https://www.ready.gov/get-tech-ready) when you know a hurricane is in the forecast and purchase backup charging devices to power electronics.
+*   **Gather Supplies**
+    *   [Have enough supplies](https://www.ready.gov/kit) for your household. Include medication, disinfectant supplies and [pet supplies](https://www.ready.gov/pets) in your go bag or car trunk. You may not have access to these supplies for days or even weeks after a hurricane.
+*   **Help your Neighborhood**
+    *   Check with neighbors, [senior adults](https://www.ready.gov/seniors) or those [who may need additional help](https://www.ready.gov/disability) securing hurricane plans to see how you can be of assistance to others.
+
+During a Hurricane/Typhoon
+--------------------------
+
+*   **Stay Informed**
+    *   Pay attention to emergency information and alerts.
+    *   If you live in a mandatory [evacuation zone](https://www.ready.gov/evacuation) and local officials tell you to evacuate, do so immediately.
+*   **Dealing with the Weather**
+*   Determine how best to protect yourself from high winds and [flooding](https://www.ready.gov/floods).
+*   Take refuge in a designated storm shelter or an interior room for high winds.
+*   Go to the highest level of the building if you are trapped by flooding. Do not climb into a closed attic. You may become trapped by rising flood water.
+*   Do not walk, swim or drive through floodwaters. Turn Around. Don’t Drown! Just six inches of fast-moving water can knock you down, and one foot of moving water can sweep your vehicle away.
+
+After a Hurricane/Typhoon
+-------------------------
+
+*   Pay attention to local officials for information and special instructions.
+*   Be careful during cleanup. Wear protective clothing and use appropriate face coverings or masks if cleaning [mold](https://www.cdc.gov/mold-health/communication-resources/guide-to-mold-cleanup.html) [or other debris](https://www.cdc.gov/mold-health/communication-resources/guide-to-mold-cleanup.html). People with [asthma and other lung conditions](https://www.cdc.gov/natural-disasters/communication-resources/asthma-care-before-during-and-after-a-hurricane-or-other-tropical-storm-factsheet.html) and/or immune suppression should not enter buildings with indoor water leaks or mold growth that can be seen or smelled, even if these individuals are not allergic to mold. Children should not help with disaster cleanup work.
+*   Wear protective clothing and work with someone else.
+*   Do not touch electrical equipment if it is wet or if you are standing in water. If it is safe to do so, turn off electricity at the main breaker or fuse box to prevent electric shock.
+*   Do not wade in flood water, which can contain dangerous pathogens that cause illnesses. This water also can contain debris, chemicals, waste and wildlife. Underground or downed power lines can electrically charge the water.
+*   Save phone calls for emergencies. Phone systems often are down or busy after a disaster. Use text messages or social media to communicate with family and friends.
+*   Document any property damage with photographs. Contact your insurance company for assistance.
+
+Additional Resources
+--------------------
+
+*   [Hurricane Preparedness Graphics](https://www.ready.gov/collection/hurricane-preparedness-graphics)
+*   [Hurricane Season Preparedness Digital Toolkit](https://www.ready.gov/hurricane-toolkit)
+*   [Storm Surge Public Service Announcements](https://www.youtube.com/playlist?list=PL720Kw_OojlLoTEBMTVHJ_bDUCBYM3V4_)
+*   [FEMA Accessible: Hurricane Safety Messages](https://youtu.be/umolcYUCuow)
+*   [Prepare to Protect: Public Service Advertisements](https://www.ready.gov/videos#protect)
+*   [Flood Map Service Center](https://msc.fema.gov/portal/search)
+*   [National Flood Insurance Program](https://www.floodsmart.gov/)
+
+### Partner Resources
+
+*   [NOAA: What is the Difference Between a Hurricane and Typhoon](http://oceanservice.noaa.gov/facts/cyclone.html)
+*   [National Weather Service Hurricane Preparedness Week](https://www.weather.gov/wrn/hurricane-preparedness)
+*   [Hurricane Information Sheet (PDF)](https://www.ready.gov/sites/default/files/2020-03/hurricane_information-sheet.pdf)
+*   [CDC Hurricanes](https://www.cdc.gov/disasters/hurricanes/index.html)
+*   [National Storm Surge Hazard Maps](https://www.nhc.noaa.gov/nationalsurge/) to determine your vulnerability
+
+If you are a disaster survivor, please visit [FEMA.gov](http://www.fema.gov) for up-to-date information on current disaster declarations.

--- a/backend/tests/test_chat_guidance.py
+++ b/backend/tests/test_chat_guidance.py
@@ -1,0 +1,96 @@
+from app import rag_agent
+
+
+def _ask(question, monkeypatch, answer=None):
+    rag_agent.chat_histories.clear()
+    captured = {}
+
+    def fake_call_nemotron(prompt):
+        captured["prompt"] = prompt
+        return answer or (
+            "LLM-generated Ready.gov guidance.\n"
+            "Sources: Ready.gov Floods (https://www.ready.gov/floods)."
+        )
+
+    monkeypatch.setattr(rag_agent, "call_nemotron", fake_call_nemotron)
+    response = rag_agent.handle_chat_query(
+        question,
+        session_id="test-disaster-guidance",
+    )
+    return response, captured
+
+
+def test_chat_answers_flood_guidance_with_llm_markdown_context(monkeypatch):
+    response, captured = _ask("What should I do during a flood?", monkeypatch)
+
+    assert response["focus"] is None
+    assert response["highlighted_buildings"] == []
+    assert response["action"]["type"] == "none"
+    assert "LLM-generated Ready.gov guidance" in response["answer"]
+    assert "Do not walk, swim or drive through floodwaters" in captured["prompt"]
+    assert "Ready.gov Floods" in captured["prompt"]
+
+
+def test_chat_answers_hurricane_preparedness_guidance(monkeypatch):
+    response, captured = _ask(
+        "How should I prepare for a hurricane?",
+        monkeypatch,
+        answer=(
+            "LLM-generated hurricane preparedness guidance.\n"
+            "Sources: Ready.gov Hurricanes (https://www.ready.gov/hurricanes)."
+        ),
+    )
+
+    assert response["focus"] is None
+    assert "LLM-generated hurricane preparedness guidance" in response["answer"]
+    assert "Make an Emergency Plan" in captured["prompt"]
+    assert "Ready.gov Hurricanes" in captured["prompt"]
+
+
+def test_chat_routes_hurricane_facts_to_guidance(monkeypatch):
+    response, captured = _ask(
+        "hurricane facts",
+        monkeypatch,
+        answer=(
+            "LLM-generated hurricane facts.\n"
+            "Sources: Ready.gov Hurricanes (https://www.ready.gov/hurricanes)."
+        ),
+    )
+
+    assert response["focus"] is None
+    assert response["highlighted_buildings"] == []
+    assert response["action"]["type"] == "none"
+    assert "LLM-generated hurricane facts" in response["answer"]
+    assert "Ready.gov Hurricanes" in captured["prompt"]
+
+
+def test_chat_uses_both_docs_when_both_guidance_topics_are_named(monkeypatch):
+    response, captured = _ask(
+        "hurricane/ flood guidance",
+        monkeypatch,
+        answer=(
+            "LLM-generated hurricane and flood guidance.\n"
+            "Sources: Ready.gov Floods (https://www.ready.gov/floods); Ready.gov Hurricanes (https://www.ready.gov/hurricanes)."
+        ),
+    )
+
+    assert response["focus"] is None
+    assert response["action"]["type"] == "none"
+    assert "Ready.gov Floods" in captured["prompt"]
+    assert "Ready.gov Hurricanes" in captured["prompt"]
+
+
+def test_chat_allows_fema_flood_insurance_guidance(monkeypatch):
+    response, captured = _ask("What does FEMA guidance say about flood insurance?", monkeypatch)
+
+    assert response["action"]["type"] == "none"
+    assert "National Flood Insurance Program" in captured["prompt"]
+    assert "unsupported" not in response["answer"].lower()
+
+
+def test_chat_uses_both_markdown_docs_for_general_disaster_guidance(monkeypatch):
+    response, captured = _ask("Can you give me general disaster safety information?", monkeypatch)
+
+    assert response["action"]["type"] == "none"
+    assert "Ready.gov Floods" in captured["prompt"]
+    assert "Ready.gov Hurricanes" in captured["prompt"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const [chatCommand, setChatCommand] = useState<ChatMapCommand | null>(null);
+	const [highlightResetToken, setHighlightResetToken] = useState(0);
 
 	const handleChatResponse = useCallback(
 		(response: ChatResponse) => {
@@ -68,6 +69,10 @@ export default function App() {
 		[location.pathname, location.search, navigate],
 	);
 
+	const handleClearMapHighlights = useCallback(() => {
+		setHighlightResetToken((value) => value + 1);
+	}, []);
+
 	return (
 		<>
 			<Toaster position="bottom-center" richColors closeButton />
@@ -77,13 +82,29 @@ export default function App() {
 					<Route path="/dashboard" element={<Navigate to="/" replace />} />
 					<Route
 						path="/map/:disaster_name?/:xbdid?"
-						element={<MapPage chatCommand={chatCommand} />}
+						element={
+							<MapPage
+								chatCommand={chatCommand}
+								highlightResetToken={highlightResetToken}
+							/>
+						}
 					/>
-					<Route path="/map" element={<MapPage chatCommand={chatCommand} />} />
+					<Route
+						path="/map"
+						element={
+							<MapPage
+								chatCommand={chatCommand}
+								highlightResetToken={highlightResetToken}
+							/>
+						}
+					/>
 					<Route path="*" element={<NotFoundRedirect />} />
 				</Routes>
 			</Suspense>
-			<DisasterResponseAssistant onChatResponse={handleChatResponse} />
+			<DisasterResponseAssistant
+				onChatResponse={handleChatResponse}
+				onClearMapHighlights={handleClearMapHighlights}
+			/>
 		</>
 	);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,20 @@
-import { lazy, Suspense, useEffect } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import {
+	Navigate,
+	Route,
+	Routes,
+	useLocation,
+	useNavigate,
+} from "react-router-dom";
 import { Toaster, toast } from "sonner";
+import DisasterResponseAssistant from "@/components/features/DisasterResponseAssistant";
+import { SpinnerEmpty } from "@/components/ui/SpinnerEmpty";
 import Dashboard from "@/pages/Dashboard";
+import type { ChatMapCommand, ChatResponse } from "@/types/chat";
+import {
+	buildChatCommand,
+	buildChatNavigationUrl,
+} from "@/utils/chatNavigation";
 
 const MapPage = lazy(() => import("@/pages/MapPage.tsx"));
 
@@ -15,19 +28,62 @@ function NotFoundRedirect() {
 	return <Navigate to="/" replace />;
 }
 
+function RouteLoadingFallback() {
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="flex min-h-screen items-center justify-center px-4">
+				<SpinnerEmpty
+					title="Loading View"
+					description="Opening the requested map state..."
+					className="border-0"
+				/>
+			</div>
+		</div>
+	);
+}
+
 export default function App() {
+	const location = useLocation();
+	const navigate = useNavigate();
+	const [chatCommand, setChatCommand] = useState<ChatMapCommand | null>(null);
+
+	const handleChatResponse = useCallback(
+		(response: ChatResponse) => {
+			try {
+				const nextCommand = buildChatCommand(response);
+				setChatCommand(nextCommand);
+
+				const nextUrl = buildChatNavigationUrl(response);
+				if (!nextUrl) {
+					return;
+				}
+
+				if (`${location.pathname}${location.search}` !== nextUrl) {
+					navigate(nextUrl);
+				}
+			} catch (error) {
+				console.error("App chat navigation failed:", error);
+			}
+		},
+		[location.pathname, location.search, navigate],
+	);
+
 	return (
 		<>
 			<Toaster position="bottom-center" richColors closeButton />
-			<Suspense fallback={null}>
+			<Suspense fallback={<RouteLoadingFallback />}>
 				<Routes>
 					<Route path="/" element={<Dashboard />} />
 					<Route path="/dashboard" element={<Navigate to="/" replace />} />
-					<Route path="/map/:disaster_name?/:xbdid?" element={<MapPage />} />
-					<Route path="/map" element={<MapPage />} />
+					<Route
+						path="/map/:disaster_name?/:xbdid?"
+						element={<MapPage chatCommand={chatCommand} />}
+					/>
+					<Route path="/map" element={<MapPage chatCommand={chatCommand} />} />
 					<Route path="*" element={<NotFoundRedirect />} />
 				</Routes>
 			</Suspense>
+			<DisasterResponseAssistant onChatResponse={handleChatResponse} />
 		</>
 	);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,21 @@ function RouteLoadingFallback() {
 	);
 }
 
+function getCurrentMapRouteContext(pathname: string): {
+	onMapRoute: boolean;
+	disasterName: string | null;
+} {
+	const match = pathname.match(/^\/map(?:\/([^/]+))?/);
+	if (!match) {
+		return { onMapRoute: false, disasterName: null };
+	}
+
+	return {
+		onMapRoute: true,
+		disasterName: match[1] ? decodeURIComponent(match[1]) : null,
+	};
+}
+
 export default function App() {
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -59,6 +74,18 @@ export default function App() {
 					return;
 				}
 
+				const currentMapRoute = getCurrentMapRouteContext(location.pathname);
+				const targetDisasterName =
+					response.action?.params?.disaster_name?.trim() ?? null;
+				const canHandleInsideCurrentMapRoute =
+					currentMapRoute.onMapRoute &&
+					(currentMapRoute.disasterName === null ||
+						targetDisasterName === null ||
+						currentMapRoute.disasterName === targetDisasterName);
+				if (canHandleInsideCurrentMapRoute) {
+					return;
+				}
+
 				if (`${location.pathname}${location.search}` !== nextUrl) {
 					navigate(nextUrl);
 				}
@@ -67,6 +94,13 @@ export default function App() {
 			}
 		},
 		[location.pathname, location.search, navigate],
+	);
+
+	const handleRunSuggestedAction = useCallback(
+		(response: ChatResponse) => {
+			handleChatResponse(response);
+		},
+		[handleChatResponse],
 	);
 
 	const handleClearMapHighlights = useCallback(() => {
@@ -104,6 +138,7 @@ export default function App() {
 			<DisasterResponseAssistant
 				onChatResponse={handleChatResponse}
 				onClearMapHighlights={handleClearMapHighlights}
+				onRunSuggestedAction={handleRunSuggestedAction}
 			/>
 		</>
 	);

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -286,7 +286,7 @@ export default function DisasterResponseAssistant({
 								entry.role === "fieldUser"
 									? "ml-auto bg-primary text-primary-foreground border-primary p-3"
 									: entry.id === PENDING_MESSAGE_ID
-										? "bg-card text-foreground border-border shadow-sm px-3 py-2"
+										? "w-fit max-w-[72px] bg-card text-foreground border-border shadow-sm px-3 py-2"
 										: "bg-card text-foreground border-border shadow-sm p-3"
 							}`}
 						>

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,6 +1,6 @@
 /* DisasterResponsesAssistant.tsx */
 import { Eraser, SendHorizontal, Sparkles, Trash2, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatMessage, ChatResponse } from "@/types/chat";
 
 interface DisasterResponseAssistantProps {
@@ -132,12 +132,26 @@ export default function DisasterResponseAssistant({
 	const bottomRef = useRef<HTMLDivElement | null>(null);
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-	useEffect(() => {
+	const resizeComposer = useCallback(() => {
 		const textarea = inputRef.current;
 		if (!textarea) return;
-		textarea.style.height = "0px";
-		textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+		const computedStyle = window.getComputedStyle(textarea);
+		const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20;
+		const verticalPadding =
+			Number.parseFloat(computedStyle.paddingTop) +
+				Number.parseFloat(computedStyle.paddingBottom) || 0;
+		const maxHeight = lineHeight * 6 + verticalPadding;
+
+		textarea.style.height = "auto";
+		const nextHeight = Math.min(textarea.scrollHeight, maxHeight);
+		textarea.style.height = `${nextHeight}px`;
+		textarea.style.overflowY =
+			textarea.scrollHeight > maxHeight ? "auto" : "hidden";
 	}, []);
+
+	useEffect(() => {
+		resizeComposer();
+	}, [currentQuery, isOpen, resizeComposer]);
 
 	useEffect(() => {
 		if (responseLog.length > 0) {
@@ -383,7 +397,10 @@ export default function DisasterResponseAssistant({
 						<textarea
 							ref={inputRef}
 							value={currentQuery}
-							onChange={(e) => setCurrentQuery(e.target.value)}
+							onChange={(e) => {
+								setCurrentQuery(e.target.value);
+								resizeComposer();
+							}}
 							onKeyDown={(e) => {
 								if (e.key === "Enter" && !e.shiftKey) {
 									e.preventDefault();
@@ -392,7 +409,7 @@ export default function DisasterResponseAssistant({
 							}}
 							disabled={isAwaitingResponse}
 							rows={1}
-							className="max-h-40 min-h-[44px] min-w-0 flex-1 resize-none overflow-y-hidden rounded-xl border border-border bg-background px-3 py-2.5 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-70"
+							className="min-h-[44px] min-w-0 flex-1 resize-none rounded-xl border border-border bg-background px-3 py-2.5 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-70"
 							placeholder="Ask Disaster Response Assistant..."
 						/>
 						<button

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -151,7 +151,7 @@ export default function DisasterResponseAssistant({
 
 	useEffect(() => {
 		resizeComposer();
-	}, [currentQuery, isOpen, resizeComposer]);
+	}, [resizeComposer]);
 
 	useEffect(() => {
 		if (responseLog.length > 0) {

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -122,6 +122,14 @@ export default function DisasterResponseAssistant({
 		null,
 	);
 	const bottomRef = useRef<HTMLDivElement | null>(null);
+	const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+	useEffect(() => {
+		const textarea = inputRef.current;
+		if (!textarea) return;
+		textarea.style.height = "0px";
+		textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
+	}, []);
 
 	useEffect(() => {
 		if (responseLog.length > 0) {
@@ -342,14 +350,20 @@ export default function DisasterResponseAssistant({
 
 				{/* Input */}
 				<div className="border-t border-border p-3 bg-card">
-					<div className="flex gap-2">
-						<input
-							type="text"
+					<div className="flex items-end gap-2">
+						<textarea
+							ref={inputRef}
 							value={currentQuery}
 							onChange={(e) => setCurrentQuery(e.target.value)}
-							onKeyDown={(e) => e.key === "Enter" && handleQuery()}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" && !e.shiftKey) {
+									e.preventDefault();
+									handleQuery();
+								}
+							}}
 							disabled={isAwaitingResponse}
-							className="flex-1 bg-background text-foreground border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+							rows={1}
+							className="max-h-40 min-h-[42px] flex-1 resize-none overflow-y-auto bg-background text-foreground border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
 							placeholder="Ask Disaster Response Assistant..."
 						/>
 						<button

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,6 +1,12 @@
 /* DisasterResponsesAssistant.tsx */
 import { Eraser, MessageCircle, SendHorizontal, Trash2, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import type { ChatMessage, ChatResponse } from "@/types/chat";
 
 interface DisasterResponseAssistantProps {
@@ -16,6 +22,8 @@ const stripInlineMarkdown = (content: string): string =>
 		.replace(/\*(.*?)\*/g, "$1")
 		.replace(/_(.*?)_/g, "$1")
 		.replace(/`(.*?)`/g, "$1");
+
+const normalizeMessageContent = (content: string): string => content.trim();
 
 function AnimatedAssistantText({
 	content,
@@ -66,6 +74,47 @@ function AnimatedAssistantText({
 	}, [animate, content]);
 
 	return <>{content.slice(0, visibleLength)}</>;
+}
+
+function SelectableMessageText({
+	children,
+	enableTripleClickSelectAll,
+}: {
+	children: ReactNode;
+	enableTripleClickSelectAll: boolean;
+}) {
+	const containerRef = useRef<HTMLSpanElement | null>(null);
+
+	useEffect(() => {
+		const node = containerRef.current;
+		if (!node || !enableTripleClickSelectAll) {
+			return;
+		}
+
+		const handleMouseDown = (event: MouseEvent) => {
+			if (event.detail !== 3) {
+				return;
+			}
+
+			const selection = window.getSelection();
+			if (!selection) {
+				return;
+			}
+
+			const range = document.createRange();
+			range.selectNodeContents(node);
+			selection.removeAllRanges();
+			selection.addRange(range);
+			event.preventDefault();
+		};
+
+		node.addEventListener("mousedown", handleMouseDown);
+		return () => {
+			node.removeEventListener("mousedown", handleMouseDown);
+		};
+	}, [enableTripleClickSelectAll]);
+
+	return <span ref={containerRef}>{children}</span>;
 }
 
 const requiresExplicitExampleAction = (response: ChatResponse): boolean =>
@@ -195,7 +244,14 @@ export default function DisasterResponseAssistant({
 				),
 		);
 
-		return cleanedMessages.length > 0 ? cleanedMessages : [initialMessage];
+		const normalizedMessages = cleanedMessages.map((entry) => ({
+			...entry,
+			content: normalizeMessageContent(entry.content),
+		}));
+
+		return normalizedMessages.length > 0
+			? normalizedMessages
+			: [initialMessage];
 	};
 
 	const [responseLog, setResponseLog] = useState<ChatMessage[]>(() => {
@@ -264,7 +320,7 @@ export default function DisasterResponseAssistant({
 		const userEntry: ChatMessage = {
 			id: crypto.randomUUID(),
 			role: "fieldUser",
-			content: currentQuery,
+			content: normalizeMessageContent(currentQuery),
 		};
 		const pendingMessageId = crypto.randomUUID();
 		setResponseLog((prev) => [...prev, userEntry]);
@@ -311,10 +367,11 @@ export default function DisasterResponseAssistant({
 			const assistantEntry: ChatMessage = {
 				id: crypto.randomUUID(),
 				role: "responseAssistant",
-				content:
+				content: normalizeMessageContent(
 					data.answer ||
-					data.response ||
-					"Your request has been received. Results will appear here.",
+						data.response ||
+						"Your request has been received. Results will appear here.",
+				),
 				mapCommandSummary: requiresExplicitExampleAction(data)
 					? autoRunExplicitExample
 						? buildMapCommandSummary(data)
@@ -451,21 +508,27 @@ export default function DisasterResponseAssistant({
 									</div>
 								) : (
 									<div className="whitespace-pre-wrap break-words leading-6">
-										<AnimatedAssistantText
-											content={stripInlineMarkdown(entry.content)}
-											animate={
-												entry.role === "responseAssistant" &&
-												animatingMessageId === entry.id
-											}
-											onProgress={() =>
-												bottomRef.current?.scrollIntoView({ behavior: "auto" })
-											}
-											onComplete={() => {
-												if (animatingMessageId === entry.id) {
-													setAnimatingMessageId(null);
+										<SelectableMessageText
+											enableTripleClickSelectAll={entry.role === "fieldUser"}
+										>
+											<AnimatedAssistantText
+												content={stripInlineMarkdown(entry.content)}
+												animate={
+													entry.role === "responseAssistant" &&
+													animatingMessageId === entry.id
 												}
-											}}
-										/>
+												onProgress={() =>
+													bottomRef.current?.scrollIntoView({
+														behavior: "auto",
+													})
+												}
+												onComplete={() => {
+													if (animatingMessageId === entry.id) {
+														setAnimatingMessageId(null);
+													}
+												}}
+											/>
+										</SelectableMessageText>
 									</div>
 								)}
 								{entry.mapCommandSummary ? (

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -9,8 +9,6 @@ interface DisasterResponseAssistantProps {
 	onRunSuggestedAction?: (response: ChatResponse) => void;
 }
 
-const PENDING_MESSAGE_ID = "assistant-pending";
-
 const stripInlineMarkdown = (content: string): string =>
 	content
 		.replace(/\*\*(.*?)\*\*/g, "$1")
@@ -75,12 +73,64 @@ const requiresExplicitExampleAction = (response: ChatResponse): boolean =>
 	response.action?.target === "map" &&
 	!response.focus;
 
+const shouldAutoRunExplicitExample = (
+	query: string,
+	response: ChatResponse,
+): boolean => {
+	if (!requiresExplicitExampleAction(response)) {
+		return false;
+	}
+
+	const normalizedQuery = query.trim().toLowerCase();
+	return (
+		normalizedQuery.startsWith("show ") ||
+		normalizedQuery.startsWith("show me ") ||
+		normalizedQuery.startsWith("take me ") ||
+		normalizedQuery.startsWith("open ") ||
+		normalizedQuery.startsWith("go to ")
+	);
+};
+
+const buildExplicitExampleSummary = (
+	response: ChatResponse,
+): string | undefined => {
+	const targetXbdId = response.action?.params?.xbd_id;
+	const addressText =
+		typeof response.action?.params?.address === "string"
+			? response.action.params.address
+			: undefined;
+
+	if (addressText && typeof targetXbdId === "number") {
+		return `Matched buildings for ${addressText}. Representative scene available on XBD ${targetXbdId}.`;
+	}
+	if (addressText) {
+		return `Matched buildings for ${addressText}. Representative scene available.`;
+	}
+	if (typeof targetXbdId === "number") {
+		return `Representative scene available on XBD ${targetXbdId}.`;
+	}
+	return "Representative scene available.";
+};
+
 const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
 	const targetXbdId = response.action?.params?.xbd_id;
+	const actionAddress =
+		typeof response.action?.params?.address === "string"
+			? response.action.params.address
+			: undefined;
 	if (response.action?.target === "building") {
 		return typeof targetXbdId === "number"
 			? `Opened the matched building on XBD ${targetXbdId}.`
 			: "Opened the matched building on the map.";
+	}
+	if (
+		response.action?.reason === "address_query" &&
+		actionAddress &&
+		response.action?.target === "map"
+	) {
+		return typeof targetXbdId === "number"
+			? `Moved the map to ${actionAddress} on XBD ${targetXbdId}.`
+			: `Moved the map to ${actionAddress}.`;
 	}
 	if (response.action?.target === "map" && response.focus?.address) {
 		return typeof targetXbdId === "number"
@@ -114,9 +164,33 @@ export default function DisasterResponseAssistant({
 			"Hi, I'm your Disaster Response Assistant. I can help you review damage severity, impacted areas, and assessment insights. What would you like to explore?",
 	};
 
+	const sanitizeStoredMessages = (
+		messages: ChatMessage[] | null | undefined,
+	): ChatMessage[] => {
+		if (!Array.isArray(messages) || messages.length === 0) {
+			return [initialMessage];
+		}
+
+		const cleanedMessages = messages.filter(
+			(entry) =>
+				!(
+					entry.isPending ||
+					(entry.role === "responseAssistant" &&
+						entry.content === "" &&
+						!entry.mapCommandSummary &&
+						!entry.suggestedActionLabel &&
+						!entry.actionPayload)
+				),
+		);
+
+		return cleanedMessages.length > 0 ? cleanedMessages : [initialMessage];
+	};
+
 	const [responseLog, setResponseLog] = useState<ChatMessage[]>(() => {
 		const saved = sessionStorage.getItem("chatHistory");
-		return saved ? JSON.parse(saved) : [initialMessage];
+		return saved
+			? sanitizeStoredMessages(JSON.parse(saved) as ChatMessage[])
+			: [initialMessage];
 	});
 
 	// Persist only for the current browser tab/session.
@@ -160,7 +234,8 @@ export default function DisasterResponseAssistant({
 	}, [responseLog]);
 
 	useEffect(() => {
-		sessionStorage.setItem("chatHistory", JSON.stringify(responseLog));
+		const persistedMessages = responseLog.filter((entry) => !entry.isPending);
+		sessionStorage.setItem("chatHistory", JSON.stringify(persistedMessages));
 		sessionStorage.setItem("chatOpen", isOpen.toString());
 	}, [responseLog, isOpen]);
 
@@ -168,6 +243,7 @@ export default function DisasterResponseAssistant({
 		setResponseLog([initialMessage]);
 		setIsAwaitingResponse(false);
 		setAnimatingMessageId(null);
+		setCurrentQuery("");
 		sessionStorage.removeItem("chatHistory");
 	};
 
@@ -178,16 +254,19 @@ export default function DisasterResponseAssistant({
 			role: "fieldUser",
 			content: currentQuery,
 		};
+		const pendingMessageId = crypto.randomUUID();
 		setResponseLog((prev) => [...prev, userEntry]);
 		const queryToSend = currentQuery;
 		setCurrentQuery("");
+		window.requestAnimationFrame(() => resizeComposer());
 		setIsAwaitingResponse(true);
 		setResponseLog((prev) => [
 			...prev,
 			{
-				id: PENDING_MESSAGE_ID,
+				id: pendingMessageId,
 				role: "responseAssistant",
 				content: "",
+				isPending: true,
 			},
 		]);
 		try {
@@ -199,7 +278,7 @@ export default function DisasterResponseAssistant({
 			if (!backendResponse.ok) {
 				setResponseLog((prev) =>
 					prev.map((entry) =>
-						entry.id === PENDING_MESSAGE_ID
+						entry.id === pendingMessageId
 							? {
 									id: crypto.randomUUID(),
 									role: "responseAssistant",
@@ -213,6 +292,10 @@ export default function DisasterResponseAssistant({
 				return;
 			}
 			const data = (await backendResponse.json()) as ChatResponse;
+			const autoRunExplicitExample = shouldAutoRunExplicitExample(
+				queryToSend,
+				data,
+			);
 			const assistantEntry: ChatMessage = {
 				id: crypto.randomUUID(),
 				role: "responseAssistant",
@@ -221,23 +304,31 @@ export default function DisasterResponseAssistant({
 					data.response ||
 					"Your request has been received. Results will appear here.",
 				mapCommandSummary: requiresExplicitExampleAction(data)
-					? typeof data.action?.params?.xbd_id === "number"
-						? `Representative scene available on XBD ${data.action.params.xbd_id}.`
-						: "Representative scene available."
+					? autoRunExplicitExample
+						? buildMapCommandSummary(data)
+						: buildExplicitExampleSummary(data)
 					: buildMapCommandSummary(data),
 				suggestedActionLabel: requiresExplicitExampleAction(data)
-					? "Show example XBD"
+					? autoRunExplicitExample
+						? undefined
+						: "Show example XBD"
 					: undefined,
-				actionPayload: requiresExplicitExampleAction(data) ? data : undefined,
+				actionPayload:
+					requiresExplicitExampleAction(data) && !autoRunExplicitExample
+						? data
+						: undefined,
 			};
 			setResponseLog((prev) =>
 				prev.map((entry) =>
-					entry.id === PENDING_MESSAGE_ID ? assistantEntry : entry,
+					entry.id === pendingMessageId ? assistantEntry : entry,
 				),
 			);
 			setIsAwaitingResponse(false);
 			setAnimatingMessageId(assistantEntry.id);
-			if (onChatResponse && !requiresExplicitExampleAction(data)) {
+			if (
+				onChatResponse &&
+				(!requiresExplicitExampleAction(data) || autoRunExplicitExample)
+			) {
 				try {
 					onChatResponse(data);
 				} catch (error) {
@@ -247,7 +338,7 @@ export default function DisasterResponseAssistant({
 		} catch {
 			setResponseLog((prev) =>
 				prev.map((entry) =>
-					entry.id === PENDING_MESSAGE_ID
+					entry.id === pendingMessageId
 						? {
 								id: crypto.randomUUID(),
 								role: "responseAssistant",
@@ -335,12 +426,12 @@ export default function DisasterResponseAssistant({
 								className={`rounded-2xl border transition-colors duration-theme ease-theme ${
 									entry.role === "fieldUser"
 										? "bg-primary px-3.5 py-3 text-primary-foreground border-primary shadow-sm"
-										: entry.id === PENDING_MESSAGE_ID
+										: entry.isPending
 											? "w-fit max-w-[72px] border-border bg-card px-3 py-2 text-foreground shadow-sm"
 											: "border-border bg-card px-3.5 py-3 text-foreground shadow-sm"
 								}`}
 							>
-								{entry.id === PENDING_MESSAGE_ID ? (
+								{entry.isPending ? (
 									<div className="flex items-center gap-1.5 py-1">
 										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
 										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -6,7 +6,66 @@ import type { ChatMessage, ChatResponse } from "@/types/chat";
 interface DisasterResponseAssistantProps {
 	onChatResponse?: (response: ChatResponse) => void;
 	onClearMapHighlights?: () => void;
+	onRunSuggestedAction?: (response: ChatResponse) => void;
 }
+
+const PENDING_MESSAGE_ID = "assistant-pending";
+
+function AnimatedAssistantText({
+	content,
+	animate,
+	onProgress,
+	onComplete,
+}: {
+	content: string;
+	animate: boolean;
+	onProgress?: () => void;
+	onComplete?: () => void;
+}) {
+	const [visibleLength, setVisibleLength] = useState(
+		animate ? 0 : content.length,
+	);
+	const onProgressRef = useRef(onProgress);
+	const onCompleteRef = useRef(onComplete);
+
+	useEffect(() => {
+		onProgressRef.current = onProgress;
+		onCompleteRef.current = onComplete;
+	}, [onProgress, onComplete]);
+
+	useEffect(() => {
+		if (!animate) {
+			setVisibleLength(content.length);
+			return;
+		}
+
+		setVisibleLength(0);
+		if (!content) return;
+
+		let index = 0;
+		const timer = window.setInterval(() => {
+			index += 3;
+			if (index >= content.length) {
+				window.clearInterval(timer);
+				setVisibleLength(content.length);
+				onProgressRef.current?.();
+				onCompleteRef.current?.();
+				return;
+			}
+			setVisibleLength(index);
+			onProgressRef.current?.();
+		}, 12);
+
+		return () => window.clearInterval(timer);
+	}, [animate, content]);
+
+	return <>{content.slice(0, visibleLength)}</>;
+}
+
+const requiresExplicitExampleAction = (response: ChatResponse): boolean =>
+	response.action?.reason === "address_query" &&
+	response.action?.target === "map" &&
+	!response.focus;
 
 const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
 	const targetXbdId = response.action?.params?.xbd_id;
@@ -33,6 +92,7 @@ const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
 export default function DisasterResponseAssistant({
 	onChatResponse,
 	onClearMapHighlights,
+	onRunSuggestedAction,
 }: DisasterResponseAssistantProps) {
 	const API_BASE_URL = import.meta.env.VITE_HAZARDLY_API_BASE_URL?.replace(
 		/\/*$/,
@@ -57,14 +117,17 @@ export default function DisasterResponseAssistant({
 	});
 
 	const [currentQuery, setCurrentQuery] = useState("");
+	const [isAwaitingResponse, setIsAwaitingResponse] = useState(false);
+	const [animatingMessageId, setAnimatingMessageId] = useState<string | null>(
+		null,
+	);
 	const bottomRef = useRef<HTMLDivElement | null>(null);
-	const messageCount = responseLog.length;
 
 	useEffect(() => {
-		if (messageCount > 0) {
+		if (responseLog.length > 0) {
 			bottomRef.current?.scrollIntoView({ behavior: "smooth" });
 		}
-	}, [messageCount]);
+	}, [responseLog]);
 
 	useEffect(() => {
 		sessionStorage.setItem("chatHistory", JSON.stringify(responseLog));
@@ -73,11 +136,13 @@ export default function DisasterResponseAssistant({
 
 	const clearChat = () => {
 		setResponseLog([initialMessage]);
+		setIsAwaitingResponse(false);
+		setAnimatingMessageId(null);
 		sessionStorage.removeItem("chatHistory");
 	};
 
 	const handleQuery = async () => {
-		if (!currentQuery.trim()) return;
+		if (!currentQuery.trim() || isAwaitingResponse) return;
 		const userEntry: ChatMessage = {
 			id: crypto.randomUUID(),
 			role: "fieldUser",
@@ -86,6 +151,15 @@ export default function DisasterResponseAssistant({
 		setResponseLog((prev) => [...prev, userEntry]);
 		const queryToSend = currentQuery;
 		setCurrentQuery("");
+		setIsAwaitingResponse(true);
+		setResponseLog((prev) => [
+			...prev,
+			{
+				id: PENDING_MESSAGE_ID,
+				role: "responseAssistant",
+				content: "",
+			},
+		]);
 		try {
 			const backendResponse = await fetch(`${API_BASE_URL}/chat`, {
 				method: "POST",
@@ -93,15 +167,19 @@ export default function DisasterResponseAssistant({
 				body: JSON.stringify({ question: queryToSend }),
 			});
 			if (!backendResponse.ok) {
-				setResponseLog((prev) => [
-					...prev,
-					{
-						id: crypto.randomUUID(),
-						role: "responseAssistant",
-						content:
-							"I'm having trouble reaching the backend service right now. Please try again.",
-					},
-				]);
+				setResponseLog((prev) =>
+					prev.map((entry) =>
+						entry.id === PENDING_MESSAGE_ID
+							? {
+									id: crypto.randomUUID(),
+									role: "responseAssistant",
+									content:
+										"I'm having trouble reaching the backend service right now. Please try again.",
+								}
+							: entry,
+					),
+				);
+				setIsAwaitingResponse(false);
 				return;
 			}
 			const data = (await backendResponse.json()) as ChatResponse;
@@ -112,10 +190,24 @@ export default function DisasterResponseAssistant({
 					data.answer ||
 					data.response ||
 					"Your request has been received. Results will appear here.",
-				mapCommandSummary: buildMapCommandSummary(data),
+				mapCommandSummary: requiresExplicitExampleAction(data)
+					? typeof data.action?.params?.xbd_id === "number"
+						? `Representative scene available on XBD ${data.action.params.xbd_id}.`
+						: "Representative scene available."
+					: buildMapCommandSummary(data),
+				suggestedActionLabel: requiresExplicitExampleAction(data)
+					? "Show example XBD"
+					: undefined,
+				actionPayload: requiresExplicitExampleAction(data) ? data : undefined,
 			};
-			setResponseLog((prev) => [...prev, assistantEntry]);
-			if (onChatResponse) {
+			setResponseLog((prev) =>
+				prev.map((entry) =>
+					entry.id === PENDING_MESSAGE_ID ? assistantEntry : entry,
+				),
+			);
+			setIsAwaitingResponse(false);
+			setAnimatingMessageId(assistantEntry.id);
+			if (onChatResponse && !requiresExplicitExampleAction(data)) {
 				try {
 					onChatResponse(data);
 				} catch (error) {
@@ -123,15 +215,20 @@ export default function DisasterResponseAssistant({
 				}
 			}
 		} catch {
-			setResponseLog((prev) => [
-				...prev,
-				{
-					id: crypto.randomUUID(),
-					role: "responseAssistant",
-					content:
-						"I'm having trouble reaching the backend service right now. Please try again.",
-				},
-			]);
+			setResponseLog((prev) =>
+				prev.map((entry) =>
+					entry.id === PENDING_MESSAGE_ID
+						? {
+								id: crypto.randomUUID(),
+								role: "responseAssistant",
+								content:
+									"I'm having trouble reaching the backend service right now. Please try again.",
+							}
+						: entry,
+				),
+			);
+			setIsAwaitingResponse(false);
+			setAnimatingMessageId(null);
 		}
 	};
 
@@ -185,16 +282,55 @@ export default function DisasterResponseAssistant({
 					{responseLog.map((entry) => (
 						<div
 							key={entry.id}
-							className={`p-3 rounded-xl max-w-[85%] border transition-colors duration-theme ease-theme ${
+							className={`rounded-xl max-w-[85%] border transition-colors duration-theme ease-theme ${
 								entry.role === "fieldUser"
-									? "ml-auto bg-primary text-primary-foreground border-primary"
-									: "bg-card text-foreground border-border shadow-sm"
+									? "ml-auto bg-primary text-primary-foreground border-primary p-3"
+									: entry.id === PENDING_MESSAGE_ID
+										? "bg-card text-foreground border-border shadow-sm px-3 py-2"
+										: "bg-card text-foreground border-border shadow-sm p-3"
 							}`}
 						>
-							{entry.content}
+							{entry.id === PENDING_MESSAGE_ID ? (
+								<div className="flex items-center gap-1.5 py-1">
+									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
+									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />
+									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
+								</div>
+							) : (
+								<AnimatedAssistantText
+									content={entry.content}
+									animate={
+										entry.role === "responseAssistant" &&
+										animatingMessageId === entry.id
+									}
+									onProgress={() =>
+										bottomRef.current?.scrollIntoView({ behavior: "auto" })
+									}
+									onComplete={() => {
+										if (animatingMessageId === entry.id) {
+											setAnimatingMessageId(null);
+										}
+									}}
+								/>
+							)}
 							{entry.mapCommandSummary ? (
 								<div className="mt-2 border-t border-border/70 pt-2 text-xs text-muted-foreground">
 									{entry.mapCommandSummary}
+								</div>
+							) : null}
+							{entry.suggestedActionLabel && entry.actionPayload ? (
+								<div className="mt-3">
+									<button
+										type="button"
+										onClick={() => {
+											if (entry.actionPayload) {
+												onRunSuggestedAction?.(entry.actionPayload);
+											}
+										}}
+										className="inline-flex items-center rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+									>
+										{entry.suggestedActionLabel}
+									</button>
 								</div>
 							) : null}
 						</div>
@@ -210,15 +346,17 @@ export default function DisasterResponseAssistant({
 							value={currentQuery}
 							onChange={(e) => setCurrentQuery(e.target.value)}
 							onKeyDown={(e) => e.key === "Enter" && handleQuery()}
+							disabled={isAwaitingResponse}
 							className="flex-1 bg-background text-foreground border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
 							placeholder="Ask Disaster Response Assistant..."
 						/>
 						<button
 							type="button"
 							onClick={handleQuery}
+							disabled={isAwaitingResponse}
 							className="bg-primary text-primary-foreground px-4 py-2 rounded-md text-sm hover:opacity-90"
 						>
-							Send
+							{isAwaitingResponse ? "Waiting..." : "Send"}
 						</button>
 					</div>
 				</div>

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -217,6 +217,12 @@ export default function DisasterResponseAssistant({
 		/\/*$/,
 		"",
 	);
+	const [chatSessionId, setChatSessionId] = useState(() => {
+		const storedSessionId = sessionStorage.getItem("chatSessionId");
+		const sessionId = storedSessionId || crypto.randomUUID();
+		sessionStorage.setItem("chatSessionId", sessionId);
+		return sessionId;
+	});
 
 	const initialMessage: ChatMessage = {
 		id: crypto.randomUUID(),
@@ -308,6 +314,9 @@ export default function DisasterResponseAssistant({
 	}, [responseLog, isOpen]);
 
 	const clearChat = () => {
+		const sessionId = crypto.randomUUID();
+		sessionStorage.setItem("chatSessionId", sessionId);
+		setChatSessionId(sessionId);
 		setResponseLog([initialMessage]);
 		setIsAwaitingResponse(false);
 		setAnimatingMessageId(null);
@@ -341,7 +350,10 @@ export default function DisasterResponseAssistant({
 			const backendResponse = await fetch(`${API_BASE_URL}/chat`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ question: queryToSend }),
+				body: JSON.stringify({
+					question: queryToSend,
+					session_id: chatSessionId,
+				}),
 			});
 			if (!backendResponse.ok) {
 				setResponseLog((prev) =>

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -129,6 +129,14 @@ const requiresExplicitExampleAction = (response: ChatResponse): boolean =>
 	response.action?.target === "map" &&
 	!response.focus;
 
+const isStreetLevelAddress = (address: string | undefined): boolean => {
+	if (!address) return false;
+
+	return /\b(street|st|avenue|ave|road|rd|drive|dr|boulevard|blvd|lane|ln|way|court|ct|place|pl|circle|cir|parkway|pkwy|highway|hwy)\b/i.test(
+		address,
+	);
+};
+
 const shouldAutoRunExplicitExample = (
 	query: string,
 	response: ChatResponse,
@@ -138,7 +146,21 @@ const shouldAutoRunExplicitExample = (
 	}
 
 	const normalizedQuery = query.trim().toLowerCase();
+	const isRepairCountQuery =
+		(normalizedQuery.startsWith("how many ") ||
+			normalizedQuery.startsWith("count ") ||
+			normalizedQuery.startsWith("number of ")) &&
+		(normalizedQuery.includes("need repair") ||
+			normalizedQuery.includes("need to be repaired") ||
+			normalizedQuery.includes("repaired") ||
+			normalizedQuery.includes("repair"));
+	const actionAddress =
+		typeof response.action?.params?.address === "string"
+			? response.action.params.address
+			: undefined;
+
 	return (
+		(isRepairCountQuery && isStreetLevelAddress(actionAddress)) ||
 		normalizedQuery.startsWith("show ") ||
 		normalizedQuery.startsWith("show me ") ||
 		normalizedQuery.startsWith("take me ") ||

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,5 +1,5 @@
 /* DisasterResponsesAssistant.tsx */
-import { Eraser, SendHorizontal, Sparkles, Trash2, X } from "lucide-react";
+import { Eraser, MessageCircle, SendHorizontal, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatMessage, ChatResponse } from "@/types/chat";
 
@@ -161,7 +161,7 @@ export default function DisasterResponseAssistant({
 		id: crypto.randomUUID(),
 		role: "responseAssistant",
 		content:
-			"Hi, I'm your Disaster Response Assistant. I can help you review damage severity, impacted areas, and assessment insights. What would you like to explore?",
+			"Hi, I'm Hazardly. I can help you review damage severity, impacted areas, and assessment insights. What would you like to explore?",
 	};
 
 	const sanitizeStoredMessages = (
@@ -364,8 +364,8 @@ export default function DisasterResponseAssistant({
 				<div className="flex items-center justify-between border-b border-white/10 bg-gradient-to-r from-primary via-primary to-indigo-500 px-4 py-3 text-white">
 					<div className="flex flex-col">
 						<span className="flex items-center gap-2 font-semibold">
-							<Sparkles className="h-4 w-4" />
-							Disaster Response Assistant
+							<MessageCircle className="h-4 w-4" />
+							Hazardly
 						</span>
 						<span className="text-[11px] opacity-80">
 							Chat history persists in session
@@ -501,7 +501,7 @@ export default function DisasterResponseAssistant({
 							disabled={isAwaitingResponse}
 							rows={1}
 							className="min-h-[44px] min-w-0 flex-1 resize-none rounded-xl border border-border bg-background px-3 py-2.5 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-70"
-							placeholder="Ask Disaster Response Assistant..."
+							placeholder="Ask Hazardly..."
 						/>
 						<button
 							type="button"
@@ -526,7 +526,7 @@ export default function DisasterResponseAssistant({
 					<X className="h-5 w-5" />
 				) : (
 					<>
-						<Sparkles className="h-6 w-6" />
+						<MessageCircle className="h-6 w-6" />
 						<span className="absolute -bottom-1 -right-1 bg-background text-foreground text-[9px] font-semibold px-1.5 py-0.5 rounded-full border border-border">
 							AI
 						</span>

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -432,7 +432,7 @@ export default function DisasterResponseAssistant({
 										: "text-muted-foreground"
 								}`}
 							>
-								{entry.role === "fieldUser" ? "You" : "Assistant"}
+								{entry.role === "fieldUser" ? "You" : "Hazardly"}
 							</div>
 							<div
 								className={`rounded-2xl border transition-colors duration-theme ease-theme ${

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,10 +1,11 @@
 /* DisasterResponsesAssistant.tsx */
-import { Sparkles, Trash2, X } from "lucide-react";
+import { Eraser, Sparkles, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { ChatMessage, ChatResponse } from "@/types/chat";
 
 interface DisasterResponseAssistantProps {
 	onChatResponse?: (response: ChatResponse) => void;
+	onClearMapHighlights?: () => void;
 }
 
 const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
@@ -26,6 +27,7 @@ const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
 
 export default function DisasterResponseAssistant({
 	onChatResponse,
+	onClearMapHighlights,
 }: DisasterResponseAssistantProps) {
 	const API_BASE_URL = import.meta.env.VITE_HAZARDLY_API_BASE_URL?.replace(
 		/\/*$/,
@@ -147,6 +149,15 @@ export default function DisasterResponseAssistant({
 						</span>
 					</div>
 					<div className="flex items-center gap-2">
+						<button
+							type="button"
+							onClick={onClearMapHighlights}
+							className="p-1 rounded-md transition-colors duration-200 hover:bg-white/20"
+							aria-label="Clear highlighted buildings"
+							title="Clear highlights"
+						>
+							<Eraser className="h-4 w-4" />
+						</button>
 						<button
 							type="button"
 							onClick={clearChat}

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -9,11 +9,16 @@ interface DisasterResponseAssistantProps {
 }
 
 const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
+	const targetXbdId = response.action?.params?.xbd_id;
 	if (response.action?.target === "building") {
-		return "Opened the matched building on the map.";
+		return typeof targetXbdId === "number"
+			? `Opened the matched building on XBD ${targetXbdId}.`
+			: "Opened the matched building on the map.";
 	}
 	if (response.action?.target === "map" && response.focus?.address) {
-		return `Moved the map to ${response.focus.address}.`;
+		return typeof targetXbdId === "number"
+			? `Moved the map to ${response.focus.address} on XBD ${targetXbdId}.`
+			: `Moved the map to ${response.focus.address}.`;
 	}
 	if (response.highlighted_buildings.length > 0) {
 		const count = response.highlighted_buildings.length;

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -118,6 +118,14 @@ const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
 		typeof response.action?.params?.address === "string"
 			? response.action.params.address
 			: undefined;
+	const displayAddress = response.focus?.address ?? actionAddress;
+	const totalMatchedBuildings =
+		response.action?.params?.building_ids?.length ?? 0;
+	const showingRepresentativeScene =
+		typeof targetXbdId === "number" &&
+		totalMatchedBuildings > 0 &&
+		response.highlighted_buildings.length > 0 &&
+		totalMatchedBuildings > response.highlighted_buildings.length;
 	if (response.action?.target === "building") {
 		return typeof targetXbdId === "number"
 			? `Opened the matched building on XBD ${targetXbdId}.`
@@ -125,16 +133,20 @@ const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
 	}
 	if (
 		response.action?.reason === "address_query" &&
-		actionAddress &&
+		displayAddress &&
 		response.action?.target === "map"
 	) {
 		return typeof targetXbdId === "number"
-			? `Moved the map to ${actionAddress} on XBD ${targetXbdId}.`
-			: `Moved the map to ${actionAddress}.`;
+			? showingRepresentativeScene
+				? `Moved the map to ${displayAddress}, showing representative XBD ${targetXbdId}.`
+				: `Moved the map to ${displayAddress} on XBD ${targetXbdId}.`
+			: `Moved the map to ${displayAddress}.`;
 	}
 	if (response.action?.target === "map" && response.focus?.address) {
 		return typeof targetXbdId === "number"
-			? `Moved the map to ${response.focus.address} on XBD ${targetXbdId}.`
+			? showingRepresentativeScene
+				? `Moved the map to ${response.focus.address}, showing representative XBD ${targetXbdId}.`
+				: `Moved the map to ${response.focus.address} on XBD ${targetXbdId}.`
 			: `Moved the map to ${response.focus.address}.`;
 	}
 	if (response.highlighted_buildings.length > 0) {

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,5 +1,5 @@
 /* DisasterResponsesAssistant.tsx */
-import { Eraser, Sparkles, Trash2, X } from "lucide-react";
+import { Eraser, SendHorizontal, Sparkles, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { ChatMessage, ChatResponse } from "@/types/chat";
 
@@ -10,6 +10,14 @@ interface DisasterResponseAssistantProps {
 }
 
 const PENDING_MESSAGE_ID = "assistant-pending";
+
+const stripInlineMarkdown = (content: string): string =>
+	content
+		.replace(/\*\*(.*?)\*\*/g, "$1")
+		.replace(/__(.*?)__/g, "$1")
+		.replace(/\*(.*?)\*/g, "$1")
+		.replace(/_(.*?)_/g, "$1")
+		.replace(/`(.*?)`/g, "$1");
 
 function AnimatedAssistantText({
 	content,
@@ -243,12 +251,12 @@ export default function DisasterResponseAssistant({
 	return (
 		<div className="pointer-events-none fixed bottom-6 right-6 z-[9999] flex flex-col items-end gap-3">
 			<div
-				className={`chat-panel-container pointer-events-auto w-[min(360px,calc(100vw-3rem))] h-[min(calc(100dvh-12rem),700px)] bg-card text-card-foreground border border-border shadow-2xl rounded-2xl flex flex-col overflow-hidden ${
+				className={`chat-panel-container pointer-events-auto w-[min(408px,calc(100vw-2rem))] h-[min(calc(100dvh-10rem),720px)] overflow-hidden rounded-2xl border border-border bg-card text-card-foreground shadow-2xl backdrop-blur-sm flex flex-col ${
 					isOpen ? "chat-panel-open" : "chat-panel-closed"
 				}`}
 			>
 				{/* Header */}
-				<div className="flex items-center justify-between px-4 py-3 border-b bg-gradient-to-r from-primary to-indigo-500 text-white">
+				<div className="flex items-center justify-between border-b border-white/10 bg-gradient-to-r from-primary via-primary to-indigo-500 px-4 py-3 text-white">
 					<div className="flex flex-col">
 						<span className="flex items-center gap-2 font-semibold">
 							<Sparkles className="h-4 w-4" />
@@ -262,7 +270,7 @@ export default function DisasterResponseAssistant({
 						<button
 							type="button"
 							onClick={onClearMapHighlights}
-							className="p-1 rounded-md transition-colors duration-200 hover:bg-white/20"
+							className="rounded-md p-1.5 transition-colors duration-200 hover:bg-white/15"
 							aria-label="Clear highlighted buildings"
 							title="Clear highlights"
 						>
@@ -271,14 +279,18 @@ export default function DisasterResponseAssistant({
 						<button
 							type="button"
 							onClick={clearChat}
-							className="p-1 rounded-md transition-colors duration-200 hover:bg-white/20"
+							className="rounded-md p-1.5 transition-colors duration-200 hover:bg-white/15"
+							aria-label="Clear chat"
+							title="Clear chat"
 						>
 							<Trash2 className="h-4 w-4" />
 						</button>
 						<button
 							type="button"
 							onClick={() => setIsOpen(false)}
-							className="ui-fade-opacity hover:opacity-80"
+							className="rounded-md p-1.5 transition-colors duration-200 hover:bg-white/15"
+							aria-label="Close chat"
+							title="Close"
 						>
 							<X className="h-4 w-4" />
 						</button>
@@ -286,71 +298,88 @@ export default function DisasterResponseAssistant({
 				</div>
 
 				{/* Messages */}
-				<div className="flex-1 p-4 overflow-y-auto text-sm space-y-4 bg-background">
+				<div className="flex-1 space-y-4 overflow-y-auto bg-muted/20 p-4 text-sm">
 					{responseLog.map((entry) => (
 						<div
 							key={entry.id}
-							className={`rounded-xl max-w-[85%] border transition-colors duration-theme ease-theme ${
+							className={
 								entry.role === "fieldUser"
-									? "ml-auto bg-primary text-primary-foreground border-primary p-3"
-									: entry.id === PENDING_MESSAGE_ID
-										? "w-fit max-w-[72px] bg-card text-foreground border-border shadow-sm px-3 py-2"
-										: "bg-card text-foreground border-border shadow-sm p-3"
-							}`}
+									? "ml-auto max-w-[88%]"
+									: "max-w-[88%]"
+							}
 						>
-							{entry.id === PENDING_MESSAGE_ID ? (
-								<div className="flex items-center gap-1.5 py-1">
-									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
-									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />
-									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
-								</div>
-							) : (
-								<div className="whitespace-pre-wrap break-words">
-									<AnimatedAssistantText
-										content={entry.content}
-										animate={
-											entry.role === "responseAssistant" &&
-											animatingMessageId === entry.id
-										}
-										onProgress={() =>
-											bottomRef.current?.scrollIntoView({ behavior: "auto" })
-										}
-										onComplete={() => {
-											if (animatingMessageId === entry.id) {
-												setAnimatingMessageId(null);
+							<div
+								className={`mb-1 px-1 text-[11px] font-medium uppercase tracking-[0.08em] ${
+									entry.role === "fieldUser"
+										? "text-right text-primary/80"
+										: "text-muted-foreground"
+								}`}
+							>
+								{entry.role === "fieldUser" ? "You" : "Assistant"}
+							</div>
+							<div
+								className={`rounded-2xl border transition-colors duration-theme ease-theme ${
+									entry.role === "fieldUser"
+										? "bg-primary px-3.5 py-3 text-primary-foreground border-primary shadow-sm"
+										: entry.id === PENDING_MESSAGE_ID
+											? "w-fit max-w-[72px] border-border bg-card px-3 py-2 text-foreground shadow-sm"
+											: "border-border bg-card px-3.5 py-3 text-foreground shadow-sm"
+								}`}
+							>
+								{entry.id === PENDING_MESSAGE_ID ? (
+									<div className="flex items-center gap-1.5 py-1">
+										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
+										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />
+										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
+									</div>
+								) : (
+									<div className="whitespace-pre-wrap break-words leading-6">
+										<AnimatedAssistantText
+											content={stripInlineMarkdown(entry.content)}
+											animate={
+												entry.role === "responseAssistant" &&
+												animatingMessageId === entry.id
 											}
-										}}
-									/>
-								</div>
-							)}
-							{entry.mapCommandSummary ? (
-								<div className="mt-2 border-t border-border/70 pt-2 text-xs text-muted-foreground">
-									{entry.mapCommandSummary}
-								</div>
-							) : null}
-							{entry.suggestedActionLabel && entry.actionPayload ? (
-								<div className="mt-3">
-									<button
-										type="button"
-										onClick={() => {
-											if (entry.actionPayload) {
-												onRunSuggestedAction?.(entry.actionPayload);
+											onProgress={() =>
+												bottomRef.current?.scrollIntoView({ behavior: "auto" })
 											}
-										}}
-										className="inline-flex items-center rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-									>
-										{entry.suggestedActionLabel}
-									</button>
-								</div>
-							) : null}
+											onComplete={() => {
+												if (animatingMessageId === entry.id) {
+													setAnimatingMessageId(null);
+												}
+											}}
+										/>
+									</div>
+								)}
+								{entry.mapCommandSummary ? (
+									<div className="mt-3 border-t border-border/70 pt-2 text-xs text-muted-foreground">
+										{entry.mapCommandSummary}
+									</div>
+								) : null}
+								{entry.suggestedActionLabel && entry.actionPayload ? (
+									<div className="mt-3">
+										<button
+											type="button"
+											onClick={() => {
+												if (entry.actionPayload) {
+													onRunSuggestedAction?.(entry.actionPayload);
+												}
+											}}
+											className="inline-flex items-center rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+										>
+											{entry.suggestedActionLabel}
+										</button>
+									</div>
+								) : null}
+							</div>
 						</div>
 					))}
 					<div ref={bottomRef} />
 				</div>
 
 				{/* Input */}
-				<div className="border-t border-border p-3 bg-card">
-					<div className="flex items-end gap-2">
+				<div className="border-t border-border bg-card p-3">
+					<div className="flex items-center gap-2">
 						<textarea
 							ref={inputRef}
 							value={currentQuery}
@@ -363,16 +392,17 @@ export default function DisasterResponseAssistant({
 							}}
 							disabled={isAwaitingResponse}
 							rows={1}
-							className="max-h-40 min-h-[42px] flex-1 resize-none overflow-y-auto bg-background text-foreground border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+							className="max-h-40 min-h-[44px] min-w-0 flex-1 resize-none overflow-y-hidden rounded-xl border border-border bg-background px-3 py-2.5 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-70"
 							placeholder="Ask Disaster Response Assistant..."
 						/>
 						<button
 							type="button"
 							onClick={handleQuery}
 							disabled={isAwaitingResponse}
-							className="bg-primary text-primary-foreground px-4 py-2 rounded-md text-sm hover:opacity-90"
+							className="inline-flex h-11 w-[112px] shrink-0 items-center justify-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-70"
 						>
-							{isAwaitingResponse ? "Waiting..." : "Send"}
+							<SendHorizontal className="h-4 w-4" />
+							{isAwaitingResponse ? "Waiting" : "Send"}
 						</button>
 					</div>
 				</div>

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,27 +1,45 @@
 /* DisasterResponsesAssistant.tsx */
 import { Sparkles, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import type { ChatMessage, ChatResponse } from "@/types/chat";
 
-interface ResponseMessage {
-	id: string;
-	role: "fieldUser" | "responseAssistant";
-	content: string;
+interface DisasterResponseAssistantProps {
+	onChatResponse?: (response: ChatResponse) => void;
 }
 
-export default function DisasterResponseAssistant() {
+const buildMapCommandSummary = (response: ChatResponse): string | undefined => {
+	if (response.action?.target === "building") {
+		return "Opened the matched building on the map.";
+	}
+	if (response.action?.target === "map" && response.focus?.address) {
+		return `Moved the map to ${response.focus.address}.`;
+	}
+	if (response.highlighted_buildings.length > 0) {
+		const count = response.highlighted_buildings.length;
+		return `Highlighted ${count} building${count === 1 ? "" : "s"} on the map.`;
+	}
+	if (response.focus) {
+		return "Moved the map to the referenced location.";
+	}
+	return undefined;
+};
+
+export default function DisasterResponseAssistant({
+	onChatResponse,
+}: DisasterResponseAssistantProps) {
 	const API_BASE_URL = import.meta.env.VITE_HAZARDLY_API_BASE_URL?.replace(
 		/\/*$/,
 		"",
 	);
 
-	const initialMessage: ResponseMessage = {
+	const initialMessage: ChatMessage = {
 		id: crypto.randomUUID(),
 		role: "responseAssistant",
 		content:
 			"Hi, I'm your Disaster Response Assistant. I can help you review damage severity, impacted areas, and assessment insights. What would you like to explore?",
 	};
 
-	const [responseLog, setResponseLog] = useState<ResponseMessage[]>(() => {
+	const [responseLog, setResponseLog] = useState<ChatMessage[]>(() => {
 		const saved = sessionStorage.getItem("chatHistory");
 		return saved ? JSON.parse(saved) : [initialMessage];
 	});
@@ -53,7 +71,7 @@ export default function DisasterResponseAssistant() {
 
 	const handleQuery = async () => {
 		if (!currentQuery.trim()) return;
-		const userEntry: ResponseMessage = {
+		const userEntry: ChatMessage = {
 			id: crypto.randomUUID(),
 			role: "fieldUser",
 			content: currentQuery,
@@ -65,17 +83,38 @@ export default function DisasterResponseAssistant() {
 			const backendResponse = await fetch(`${API_BASE_URL}/chat`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ query: queryToSend }),
+				body: JSON.stringify({ question: queryToSend }),
 			});
-			const data = await backendResponse.json();
-			const assistantEntry: ResponseMessage = {
+			if (!backendResponse.ok) {
+				setResponseLog((prev) => [
+					...prev,
+					{
+						id: crypto.randomUUID(),
+						role: "responseAssistant",
+						content:
+							"I'm having trouble reaching the backend service right now. Please try again.",
+					},
+				]);
+				return;
+			}
+			const data = (await backendResponse.json()) as ChatResponse;
+			const assistantEntry: ChatMessage = {
 				id: crypto.randomUUID(),
 				role: "responseAssistant",
 				content:
+					data.answer ||
 					data.response ||
 					"Your request has been received. Results will appear here.",
+				mapCommandSummary: buildMapCommandSummary(data),
 			};
 			setResponseLog((prev) => [...prev, assistantEntry]);
+			if (onChatResponse) {
+				try {
+					onChatResponse(data);
+				} catch (error) {
+					console.error("Chat response handling failed:", error);
+				}
+			}
 		} catch {
 			setResponseLog((prev) => [
 				...prev,
@@ -137,6 +176,11 @@ export default function DisasterResponseAssistant() {
 							}`}
 						>
 							{entry.content}
+							{entry.mapCommandSummary ? (
+								<div className="mt-2 border-t border-border/70 pt-2 text-xs text-muted-foreground">
+									{entry.mapCommandSummary}
+								</div>
+							) : null}
 						</div>
 					))}
 					<div ref={bottomRef} />

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -1,5 +1,12 @@
 /* DisasterResponsesAssistant.tsx */
-import { Eraser, MessageCircle, SendHorizontal, Trash2, X } from "lucide-react";
+import {
+	ArrowDown,
+	Eraser,
+	MessageCircle,
+	SendHorizontal,
+	Trash2,
+	X,
+} from "lucide-react";
 import {
 	type ReactNode,
 	useCallback,
@@ -277,8 +284,52 @@ export default function DisasterResponseAssistant({
 	const [animatingMessageId, setAnimatingMessageId] = useState<string | null>(
 		null,
 	);
+	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+	const messagesContainerRef = useRef<HTMLDivElement | null>(null);
 	const bottomRef = useRef<HTMLDivElement | null>(null);
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
+	const shouldAutoScrollRef = useRef(true);
+	const isProgrammaticScrollRef = useRef(false);
+	const programmaticScrollTimerRef = useRef<number | null>(null);
+
+	const isMessagesContainerAtBottom = useCallback(() => {
+		const container = messagesContainerRef.current;
+		if (!container) return true;
+
+		const distanceFromBottom =
+			container.scrollHeight - container.scrollTop - container.clientHeight;
+		return distanceFromBottom < 64;
+	}, []);
+
+	const scrollToBottom = useCallback(
+		(behavior: ScrollBehavior = "smooth") => {
+			isProgrammaticScrollRef.current = true;
+			if (programmaticScrollTimerRef.current !== null) {
+				window.clearTimeout(programmaticScrollTimerRef.current);
+			}
+			bottomRef.current?.scrollIntoView({ behavior, block: "end" });
+			shouldAutoScrollRef.current = true;
+			setShowScrollToBottom(false);
+			programmaticScrollTimerRef.current = window.setTimeout(
+				() => {
+					isProgrammaticScrollRef.current = false;
+					programmaticScrollTimerRef.current = null;
+					setShowScrollToBottom(!isMessagesContainerAtBottom());
+				},
+				behavior === "smooth" ? 350 : 80,
+			);
+		},
+		[isMessagesContainerAtBottom],
+	);
+
+	const handleMessagesScroll = useCallback(() => {
+		if (isProgrammaticScrollRef.current) {
+			return;
+		}
+		const isAtBottom = isMessagesContainerAtBottom();
+		shouldAutoScrollRef.current = isAtBottom;
+		setShowScrollToBottom(!isAtBottom);
+	}, [isMessagesContainerAtBottom]);
 
 	const resizeComposer = useCallback(() => {
 		const textarea = inputRef.current;
@@ -302,10 +353,22 @@ export default function DisasterResponseAssistant({
 	}, [resizeComposer]);
 
 	useEffect(() => {
+		return () => {
+			if (programmaticScrollTimerRef.current !== null) {
+				window.clearTimeout(programmaticScrollTimerRef.current);
+			}
+		};
+	}, []);
+
+	useEffect(() => {
 		if (responseLog.length > 0) {
-			bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+			if (shouldAutoScrollRef.current) {
+				scrollToBottom("smooth");
+			} else {
+				setShowScrollToBottom(true);
+			}
 		}
-	}, [responseLog]);
+	}, [responseLog, scrollToBottom]);
 
 	useEffect(() => {
 		const persistedMessages = responseLog.filter((entry) => !entry.isPending);
@@ -326,6 +389,8 @@ export default function DisasterResponseAssistant({
 
 	const handleQuery = async () => {
 		if (!currentQuery.trim() || isAwaitingResponse) return;
+		shouldAutoScrollRef.current = true;
+		setShowScrollToBottom(false);
 		const userEntry: ChatMessage = {
 			id: crypto.randomUUID(),
 			role: "fieldUser",
@@ -484,89 +549,107 @@ export default function DisasterResponseAssistant({
 				</div>
 
 				{/* Messages */}
-				<div className="flex-1 space-y-4 overflow-y-auto bg-muted/20 p-4 text-sm">
-					{responseLog.map((entry) => (
-						<div
-							key={entry.id}
-							className={
-								entry.role === "fieldUser"
-									? "ml-auto max-w-[88%]"
-									: "max-w-[88%]"
-							}
-						>
+				<div className="relative min-h-0 flex-1">
+					<div
+						ref={messagesContainerRef}
+						onScroll={handleMessagesScroll}
+						className="h-full space-y-4 overflow-y-auto bg-muted/20 p-4 text-sm"
+					>
+						{responseLog.map((entry) => (
 							<div
-								className={`mb-1 px-1 text-[11px] font-medium uppercase tracking-[0.08em] ${
+								key={entry.id}
+								className={
 									entry.role === "fieldUser"
-										? "text-right text-primary/80"
-										: "text-muted-foreground"
-								}`}
+										? "ml-auto max-w-[88%]"
+										: "max-w-[88%]"
+								}
 							>
-								{entry.role === "fieldUser" ? "You" : "Hazardly"}
-							</div>
-							<div
-								className={`rounded-2xl border transition-colors duration-theme ease-theme ${
-									entry.role === "fieldUser"
-										? "bg-primary px-3.5 py-3 text-primary-foreground border-primary shadow-sm"
-										: entry.isPending
-											? "w-fit max-w-[72px] border-border bg-card px-3 py-2 text-foreground shadow-sm"
-											: "border-border bg-card px-3.5 py-3 text-foreground shadow-sm"
-								}`}
-							>
-								{entry.isPending ? (
-									<div className="flex items-center gap-1.5 py-1">
-										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
-										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />
-										<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
-									</div>
-								) : (
-									<div className="whitespace-pre-wrap break-words leading-6">
-										<SelectableMessageText
-											enableTripleClickSelectAll={entry.role === "fieldUser"}
-										>
-											<AnimatedAssistantText
-												content={stripInlineMarkdown(entry.content)}
-												animate={
-													entry.role === "responseAssistant" &&
-													animatingMessageId === entry.id
-												}
-												onProgress={() =>
-													bottomRef.current?.scrollIntoView({
-														behavior: "auto",
-													})
-												}
-												onComplete={() => {
-													if (animatingMessageId === entry.id) {
-														setAnimatingMessageId(null);
+								<div
+									className={`mb-1 px-1 text-[11px] font-medium uppercase tracking-[0.08em] ${
+										entry.role === "fieldUser"
+											? "text-right text-primary/80"
+											: "text-muted-foreground"
+									}`}
+								>
+									{entry.role === "fieldUser" ? "You" : "Hazardly"}
+								</div>
+								<div
+									className={`rounded-2xl border transition-colors duration-theme ease-theme ${
+										entry.role === "fieldUser"
+											? "bg-primary px-3.5 py-3 text-primary-foreground border-primary shadow-sm"
+											: entry.isPending
+												? "w-fit max-w-[72px] border-border bg-card px-3 py-2 text-foreground shadow-sm"
+												: "border-border bg-card px-3.5 py-3 text-foreground shadow-sm"
+									}`}
+								>
+									{entry.isPending ? (
+										<div className="flex items-center gap-1.5 py-1">
+											<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
+											<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />
+											<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
+										</div>
+									) : (
+										<div className="whitespace-pre-wrap break-words leading-6">
+											<SelectableMessageText
+												enableTripleClickSelectAll={entry.role === "fieldUser"}
+											>
+												<AnimatedAssistantText
+													content={stripInlineMarkdown(entry.content)}
+													animate={
+														entry.role === "responseAssistant" &&
+														animatingMessageId === entry.id
+													}
+													onProgress={() => {
+														if (shouldAutoScrollRef.current) {
+															scrollToBottom("auto");
+														}
+													}}
+													onComplete={() => {
+														if (animatingMessageId === entry.id) {
+															setAnimatingMessageId(null);
+														}
+													}}
+												/>
+											</SelectableMessageText>
+										</div>
+									)}
+									{entry.mapCommandSummary ? (
+										<div className="mt-3 border-t border-border/70 pt-2 text-xs text-muted-foreground">
+											{entry.mapCommandSummary}
+										</div>
+									) : null}
+									{entry.suggestedActionLabel && entry.actionPayload ? (
+										<div className="mt-3">
+											<button
+												type="button"
+												onClick={() => {
+													if (entry.actionPayload) {
+														onRunSuggestedAction?.(entry.actionPayload);
 													}
 												}}
-											/>
-										</SelectableMessageText>
-									</div>
-								)}
-								{entry.mapCommandSummary ? (
-									<div className="mt-3 border-t border-border/70 pt-2 text-xs text-muted-foreground">
-										{entry.mapCommandSummary}
-									</div>
-								) : null}
-								{entry.suggestedActionLabel && entry.actionPayload ? (
-									<div className="mt-3">
-										<button
-											type="button"
-											onClick={() => {
-												if (entry.actionPayload) {
-													onRunSuggestedAction?.(entry.actionPayload);
-												}
-											}}
-											className="inline-flex items-center rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-										>
-											{entry.suggestedActionLabel}
-										</button>
-									</div>
-								) : null}
+												className="inline-flex items-center rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+											>
+												{entry.suggestedActionLabel}
+											</button>
+										</div>
+									) : null}
+								</div>
 							</div>
-						</div>
-					))}
-					<div ref={bottomRef} />
+						))}
+						<div ref={bottomRef} />
+					</div>
+					{showScrollToBottom ? (
+						<button
+							type="button"
+							onClick={() => scrollToBottom()}
+							className="absolute bottom-3 left-1/2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-lg transition-colors hover:bg-accent"
+							aria-label="Scroll to latest chatbot message"
+							title="Scroll to bottom"
+						>
+							<ArrowDown className="h-3.5 w-3.5" />
+							Latest
+						</button>
+					) : null}
 				</div>
 
 				{/* Input */}

--- a/frontend/src/components/features/DisasterResponseAssistant.tsx
+++ b/frontend/src/components/features/DisasterResponseAssistant.tsx
@@ -297,21 +297,23 @@ export default function DisasterResponseAssistant({
 									<span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
 								</div>
 							) : (
-								<AnimatedAssistantText
-									content={entry.content}
-									animate={
-										entry.role === "responseAssistant" &&
-										animatingMessageId === entry.id
-									}
-									onProgress={() =>
-										bottomRef.current?.scrollIntoView({ behavior: "auto" })
-									}
-									onComplete={() => {
-										if (animatingMessageId === entry.id) {
-											setAnimatingMessageId(null);
+								<div className="whitespace-pre-wrap break-words">
+									<AnimatedAssistantText
+										content={entry.content}
+										animate={
+											entry.role === "responseAssistant" &&
+											animatingMessageId === entry.id
 										}
-									}}
-								/>
+										onProgress={() =>
+											bottomRef.current?.scrollIntoView({ behavior: "auto" })
+										}
+										onComplete={() => {
+											if (animatingMessageId === entry.id) {
+												setAnimatingMessageId(null);
+											}
+										}}
+									/>
+								</div>
 							)}
 							{entry.mapCommandSummary ? (
 								<div className="mt-2 border-t border-border/70 pt-2 text-xs text-muted-foreground">

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -56,6 +56,7 @@ interface MapViewProps {
 
 const CHAT_FOCUS_FALLBACK_ZOOM = 18;
 const CHAT_FIT_PADDING = 72;
+const MAP_LOADING_WATCHDOG_MS = 45000;
 
 function extendBoundsWithGeometry(
 	bounds: mapboxgl.LngLatBounds,
@@ -358,6 +359,21 @@ export default function MapView({
 	const sceneRetryCountRef = useRef(sceneRetryCount);
 	bootstrapRetryCountRef.current = bootstrapRetryCount;
 	sceneRetryCountRef.current = sceneRetryCount;
+
+	useEffect(() => {
+		if (status !== "loading") return;
+
+		const timeoutId = window.setTimeout(() => {
+			setErrorMessage(
+				"Map loading took too long and was stopped. Please retry the map.",
+			);
+			setStatus("error");
+			setSceneLoading(false);
+			onMetricsChange?.(null);
+		}, MAP_LOADING_WATCHDOG_MS);
+
+		return () => window.clearTimeout(timeoutId);
+	}, [status, onMetricsChange]);
 
 	useEffect(() => {
 		setDisasterId(initialDisasterId);

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -9,6 +9,7 @@ import { BuildingPopup } from "@/components/features/BuildingPopup";
 import { MapControls } from "@/components/features/MapControls";
 import { MapLoadingOverlay } from "@/components/features/MapLoadingOverlay";
 import { useLoadingOverlay } from "@/hooks/useLoadingOverlay";
+import type { ChatMapCommand } from "@/types/chat";
 import type { MapStatus, SceneMetrics } from "@/types/map.ts";
 import { BUILDINGS_SOURCE_ID } from "@/utils/addBuildingLayer";
 import type { BuildingFeature, BuildingsResponse } from "@/utils/hazardlyApi";
@@ -27,6 +28,7 @@ import {
 	PRE_IMAGE_LAYER_ID,
 	selectBuildingByUid,
 	setBuildingVisibility,
+	setHighlightedBuildingsByUid,
 	setImageryVisibility,
 	setSatelliteOpacity,
 	waitForMapsLoad,
@@ -47,6 +49,36 @@ interface MapViewProps {
 	canGoNext: boolean;
 	onPrev: () => void;
 	onNext: () => void;
+	chatCommand?: ChatMapCommand | null;
+}
+
+const CHAT_FOCUS_FALLBACK_ZOOM = 18;
+const CHAT_FIT_PADDING = 72;
+
+function extendBoundsWithGeometry(
+	bounds: mapboxgl.LngLatBounds,
+	geometry: GeoJSON.Geometry,
+) {
+	const extendCoordinates = (coordinates: number[][]) => {
+		for (const coordinate of coordinates) {
+			bounds.extend([coordinate[0], coordinate[1]]);
+		}
+	};
+
+	if (geometry.type === "Polygon") {
+		for (const ring of geometry.coordinates) {
+			extendCoordinates(ring);
+		}
+		return;
+	}
+
+	if (geometry.type === "MultiPolygon") {
+		for (const polygon of geometry.coordinates) {
+			for (const ring of polygon) {
+				extendCoordinates(ring);
+			}
+		}
+	}
 }
 
 function computeSceneMetrics(
@@ -286,6 +318,7 @@ export default function MapView({
 	canGoNext,
 	onPrev,
 	onNext,
+	chatCommand,
 }: MapViewProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const compareRef = useRef<Compare | null>(null);
@@ -311,6 +344,7 @@ export default function MapView({
 	const loadingOverlay = useLoadingOverlay(status);
 	const popupDataRef = useRef<PopupData | null>(null);
 	const selectedBuildingIdRef = useRef<string | number | null>(null);
+	const highlightedBuildingIdsRef = useRef<Array<string | number>>([]);
 	const imageryVisibleRef = useRef(imageryVisible);
 	const boundsRef = useRef<ImageBounds | null>(null);
 	const scheduleCompareIdleRef = useRef<() => void>(() => {});
@@ -591,6 +625,7 @@ export default function MapView({
 				compareIdleTimerRef.current = null;
 			}
 			selectedBuildingIdRef.current = null;
+			highlightedBuildingIdsRef.current = [];
 			boundsRef.current = null;
 			layersReadyRef.current = false;
 			compareRef.current?.remove();
@@ -751,6 +786,69 @@ export default function MapView({
 			container.removeEventListener("touchstart", handleActivity);
 		};
 	}, [imageryVisible, scheduleCompareIdle]);
+
+	useEffect(() => {
+		if (!chatCommand || status !== "ready" || sceneLoading) return;
+		if (chatCommand.targetXbdId && chatCommand.targetXbdId !== selectedXbdId) {
+			return;
+		}
+
+		const before = beforeMapRef.current;
+		const after = afterMapRef.current;
+		if (!before || !after || !layersReadyRef.current) return;
+
+		setBuildingsVisible((current) => {
+			if (!current) {
+				setBuildingVisibility(before, true);
+				setBuildingVisibility(after, true);
+			}
+			return true;
+		});
+
+		setHighlightedBuildingsByUid({
+			beforeMap: before,
+			afterMap: after,
+			uids: chatCommand.highlightedBuildingIds,
+			highlightedBuildingIdsRef,
+		});
+
+		if (chatCommand.highlightedBuildingGeometries.length > 0) {
+			const bounds = new mapboxgl.LngLatBounds();
+			for (const geometry of chatCommand.highlightedBuildingGeometries) {
+				extendBoundsWithGeometry(bounds, geometry);
+			}
+			if (!bounds.isEmpty()) {
+				before.fitBounds(bounds, {
+					padding: CHAT_FIT_PADDING,
+					duration: 1200,
+					maxZoom: CHAT_FOCUS_FALLBACK_ZOOM,
+				});
+				after.fitBounds(bounds, {
+					padding: CHAT_FIT_PADDING,
+					duration: 1200,
+					maxZoom: CHAT_FOCUS_FALLBACK_ZOOM,
+				});
+			}
+		} else if (chatCommand.focus) {
+			const center: [number, number] = [
+				chatCommand.focus.lon,
+				chatCommand.focus.lat,
+			];
+			const nextZoom = Math.max(before.getZoom(), CHAT_FOCUS_FALLBACK_ZOOM);
+			before.easeTo({ center, zoom: nextZoom, duration: 1200 });
+			after.easeTo({ center, zoom: nextZoom, duration: 1200 });
+		}
+
+		if (chatCommand.targetBuildingUid) {
+			selectBuildingByUid({
+				beforeMap: before,
+				afterMap: after,
+				uid: chatCommand.targetBuildingUid,
+				selectedBuildingIdRef,
+				onPopupOpen: openPopup,
+			});
+		}
+	}, [chatCommand, openPopup, sceneLoading, selectedXbdId, status]);
 
 	return (
 		<div

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -51,6 +51,7 @@ interface MapViewProps {
 	onPrev: () => void;
 	onNext: () => void;
 	chatCommand?: ChatMapCommand | null;
+	highlightResetToken?: number;
 }
 
 const CHAT_FOCUS_FALLBACK_ZOOM = 18;
@@ -320,6 +321,7 @@ export default function MapView({
 	onPrev,
 	onNext,
 	chatCommand,
+	highlightResetToken = 0,
 }: MapViewProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const compareRef = useRef<Compare | null>(null);
@@ -889,6 +891,20 @@ export default function MapView({
 			cancelled = true;
 		};
 	}, [chatCommand, openPopup, sceneLoading, selectedXbdId, status]);
+
+	useEffect(() => {
+		if (highlightResetToken === 0) return;
+
+		const before = beforeMapRef.current;
+		const after = afterMapRef.current;
+		if (!before || !after || !layersReadyRef.current) return;
+
+		clearHighlightedBuildings({
+			beforeMap: before,
+			afterMap: after,
+			highlightedBuildingIdsRef,
+		});
+	}, [highlightResetToken]);
 
 	return (
 		<div

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -805,12 +805,29 @@ export default function MapView({
 			return true;
 		});
 
-		setHighlightedBuildingsByUid({
-			beforeMap: before,
-			afterMap: after,
-			uids: chatCommand.highlightedBuildingIds,
-			highlightedBuildingIdsRef,
-		});
+		let cancelled = false;
+		const applyHighlights = () => {
+			if (cancelled) return 0;
+			return setHighlightedBuildingsByUid({
+				beforeMap: before,
+				afterMap: after,
+				uids: chatCommand.highlightedBuildingIds,
+				highlightedBuildingIdsRef,
+			});
+		};
+
+		const highlightedCount = applyHighlights();
+		if (
+			highlightedCount === 0 &&
+			chatCommand.highlightedBuildingIds.length > 0
+		) {
+			const retryHighlights = () => {
+				if (cancelled) return;
+				applyHighlights();
+			};
+			before.once("idle", retryHighlights);
+			after.once("idle", retryHighlights);
+		}
 
 		if (chatCommand.highlightedBuildingGeometries.length > 0) {
 			const bounds = new mapboxgl.LngLatBounds();
@@ -848,6 +865,10 @@ export default function MapView({
 				onPopupOpen: openPopup,
 			});
 		}
+
+		return () => {
+			cancelled = true;
+		};
 	}, [chatCommand, openPopup, sceneLoading, selectedXbdId, status]);
 
 	return (

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -21,6 +21,7 @@ import {
 import {
 	addInitialSourcesAndLayers,
 	bindBuildingInteractions,
+	clearHighlightedBuildings,
 	createCompareInstance,
 	createMapInstance,
 	POST_IMAGE_LAYER_ID,
@@ -345,6 +346,7 @@ export default function MapView({
 	const popupDataRef = useRef<PopupData | null>(null);
 	const selectedBuildingIdRef = useRef<string | number | null>(null);
 	const highlightedBuildingIdsRef = useRef<Array<string | number>>([]);
+	const lastAppliedChatCommandIdRef = useRef<string | null>(null);
 	const imageryVisibleRef = useRef(imageryVisible);
 	const boundsRef = useRef<ImageBounds | null>(null);
 	const scheduleCompareIdleRef = useRef<() => void>(() => {});
@@ -625,7 +627,15 @@ export default function MapView({
 				compareIdleTimerRef.current = null;
 			}
 			selectedBuildingIdRef.current = null;
-			highlightedBuildingIdsRef.current = [];
+			if (beforeMap && afterMap) {
+				clearHighlightedBuildings({
+					beforeMap,
+					afterMap,
+					highlightedBuildingIdsRef,
+				});
+			} else {
+				highlightedBuildingIdsRef.current = [];
+			}
 			boundsRef.current = null;
 			layersReadyRef.current = false;
 			compareRef.current?.remove();
@@ -693,6 +703,11 @@ export default function MapView({
 				popupDataRef.current = null;
 				setPopupData(null);
 				setPopupPos(null);
+				clearHighlightedBuildings({
+					beforeMap: _before,
+					afterMap: _after,
+					highlightedBuildingIdsRef,
+				});
 
 				const beforeSource = _before.getSource(
 					BUILDINGS_SOURCE_ID,
@@ -789,6 +804,9 @@ export default function MapView({
 
 	useEffect(() => {
 		if (!chatCommand || status !== "ready" || sceneLoading) return;
+		if (lastAppliedChatCommandIdRef.current === chatCommand.id) {
+			return;
+		}
 		if (chatCommand.targetXbdId && chatCommand.targetXbdId !== selectedXbdId) {
 			return;
 		}
@@ -865,6 +883,7 @@ export default function MapView({
 				onPopupOpen: openPopup,
 			});
 		}
+		lastAppliedChatCommandIdRef.current = chatCommand.id;
 
 		return () => {
 			cancelled = true;

--- a/frontend/src/components/features/MapView.tsx
+++ b/frontend/src/components/features/MapView.tsx
@@ -349,6 +349,7 @@ export default function MapView({
 	const selectedBuildingIdRef = useRef<string | number | null>(null);
 	const highlightedBuildingIdsRef = useRef<Array<string | number>>([]);
 	const lastAppliedChatCommandIdRef = useRef<string | null>(null);
+	const loadedSceneXbdIdRef = useRef<number | null>(null);
 	const imageryVisibleRef = useRef(imageryVisible);
 	const boundsRef = useRef<ImageBounds | null>(null);
 	const scheduleCompareIdleRef = useRef<() => void>(() => {});
@@ -549,6 +550,7 @@ export default function MapView({
 					});
 
 					setStatus("ready");
+					loadedSceneXbdIdRef.current = imagePair.properties.xbd_id;
 					onMetricsChange?.(
 						computeSceneMetrics(imagePair.properties.xbd_id, buildings),
 					);
@@ -645,6 +647,7 @@ export default function MapView({
 			afterMap?.remove();
 			beforeMapRef.current = null;
 			afterMapRef.current = null;
+			loadedSceneXbdIdRef.current = null;
 		};
 		// selectedXbdId is intentionally excluded; scene switches are handled by Effect 2.
 	}, [
@@ -726,6 +729,7 @@ export default function MapView({
 				_before.fitBounds([sw, ne], { padding: 0, animate: true });
 				setErrorMessage(null);
 				setStatus("ready");
+				loadedSceneXbdIdRef.current = imagePair.properties.xbd_id;
 				onMetricsChange?.(
 					computeSceneMetrics(imagePair.properties.xbd_id, buildings),
 				);
@@ -807,6 +811,9 @@ export default function MapView({
 	useEffect(() => {
 		if (!chatCommand || status !== "ready" || sceneLoading) return;
 		if (lastAppliedChatCommandIdRef.current === chatCommand.id) {
+			return;
+		}
+		if (loadedSceneXbdIdRef.current !== selectedXbdId) {
 			return;
 		}
 		if (chatCommand.targetXbdId && chatCommand.targetXbdId !== selectedXbdId) {

--- a/frontend/src/components/ui/Item.tsx
+++ b/frontend/src/components/ui/Item.tsx
@@ -1,4 +1,5 @@
 import { Maximize2 } from "lucide-react";
+import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 type ItemProps = {
@@ -7,6 +8,7 @@ type ItemProps = {
 	title: string;
 	subtitle?: string;
 	meta?: string;
+	titleAccessory?: ReactNode;
 	imageOverlayLabel?: string;
 	onImageClick?: () => void;
 	imageButtonLabel?: string;
@@ -19,6 +21,7 @@ export default function Item({
 	title,
 	subtitle,
 	meta,
+	titleAccessory,
 	imageOverlayLabel,
 	onImageClick,
 	imageButtonLabel,
@@ -67,9 +70,14 @@ export default function Item({
 			)}
 
 			<div className="min-w-0">
-				<p className="truncate text-sm font-medium text-card-foreground">
-					{title}
-				</p>
+				<div className="flex items-start gap-2">
+					<p className="min-w-0 flex-1 truncate text-sm font-medium text-card-foreground">
+						{title}
+					</p>
+					{titleAccessory ? (
+						<div className="shrink-0">{titleAccessory}</div>
+					) : null}
+				</div>
 				{subtitle && (
 					<p className="truncate text-xs text-muted-foreground">{subtitle}</p>
 				)}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import { useEffect } from "react";
 import AppSidebar from "@/components/layout/AppSidebar";
 import Container from "@/components/layout/Container";
 import Footer from "@/components/layout/Footer.tsx";
@@ -9,31 +9,11 @@ import DashboardImagePairsSection from "./dashboard/DashboardImagePairsSection";
 import DashboardOverviewSection from "./dashboard/DashboardOverviewSection";
 import { useDashboardData } from "./dashboard/useDashboardData";
 
-const DisasterResponseAssistant = lazy(
-	() => import("@/components/features/DisasterResponseAssistant.tsx"),
-);
-
 export default function Dashboard() {
 	const dashboard = useDashboardData();
-	const [showAssistant, setShowAssistant] = useState(false);
 
 	useEffect(() => {
-		const idleWindow = window as Window & {
-			requestIdleCallback?: (callback: () => void) => number;
-			cancelIdleCallback?: (id: number) => void;
-		};
-
-		if (idleWindow.requestIdleCallback) {
-			const idleId = idleWindow.requestIdleCallback(() => {
-				setShowAssistant(true);
-			});
-			return () => idleWindow.cancelIdleCallback?.(idleId);
-		}
-
-		const timeoutId = window.setTimeout(() => {
-			setShowAssistant(true);
-		}, 1200);
-		return () => window.clearTimeout(timeoutId);
+		document.title = "Dashboard";
 	}, []);
 
 	return (
@@ -127,11 +107,6 @@ export default function Dashboard() {
 					</div>
 				</div>
 			</Container>
-			{showAssistant ? (
-				<Suspense fallback={null}>
-					<DisasterResponseAssistant />
-				</Suspense>
-			) : null}
 			<Footer />
 		</div>
 	);

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,33 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-	useLocation,
-	useNavigate,
-	useParams,
-	useSearchParams,
-} from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
-import DisasterResponseAssistant from "@/components/features/DisasterResponseAssistant.tsx";
 import MapMetricsPanel from "@/components/features/MapMetricsPanel.tsx";
 import MapView from "@/components/features/MapView.tsx";
 import { useXbdSelectorState } from "@/components/features/XbdSelector";
 import Footer from "@/components/layout/Footer.tsx";
 import Header from "@/components/layout/Header.tsx";
+import { SpinnerEmpty } from "@/components/ui/SpinnerEmpty";
+import type { ChatMapCommand } from "@/types/chat";
 import type { SceneMetrics } from "@/types/map";
 import { getDisasterIdByName } from "@/utils/hazardlyApi.ts";
 
-export default function MapPage() {
+interface MapPageProps {
+	chatCommand?: ChatMapCommand | null;
+}
+
+export default function MapPage({ chatCommand = null }: MapPageProps) {
 	const { disaster_name, xbdid } = useParams<{
 		disaster_name: string;
 		xbdid: string;
 	}>();
-	const location = useLocation();
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
-	const suppressMissingSceneToast =
-		location.state !== null &&
-		typeof location.state === "object" &&
-		"suppressMissingSceneToast" in location.state &&
-		location.state.suppressMissingSceneToast === true;
+	const suppressMissingSceneToast = false;
 	const buildingFromUrl = searchParams.get("building")?.trim() ?? undefined;
 	const normalizedDisasterParam = disaster_name?.trim();
 	const requiresDisasterResolution = Boolean(normalizedDisasterParam);
@@ -132,7 +127,6 @@ export default function MapPage() {
 		isXbdMalformed,
 		disasterFallbackPath,
 		navigate,
-		suppressMissingSceneToast,
 	]);
 
 	const handleInvalidScene = useCallback(
@@ -140,11 +134,16 @@ export default function MapPage() {
 			toast.error(message);
 			navigate(disasterFallbackPath, {
 				replace: true,
-				state: { suppressMissingSceneToast: true },
 			});
 		},
 		[disasterFallbackPath, navigate],
 	);
+
+	useEffect(() => {
+		if (chatCommand?.targetXbdId && chatCommand.targetXbdId !== selectedXbdId) {
+			setSelectedXbdId(chatCommand.targetXbdId);
+		}
+	}, [chatCommand, selectedXbdId]);
 
 	const disasterId = resolvedDisasterId ?? 1;
 	const xbdSelector = useXbdSelectorState({
@@ -158,7 +157,19 @@ export default function MapPage() {
 		requiresDisasterResolution &&
 		(isLoading || resolvedDisasterId === null)
 	) {
-		return null;
+		return (
+			<div className="flex min-h-screen flex-col bg-background text-foreground">
+				<Header />
+				<div className="flex flex-1 items-center justify-center px-4">
+					<SpinnerEmpty
+						title="Loading Map"
+						description="Resolving the requested disaster and scene..."
+						className="border-0"
+					/>
+				</div>
+				<Footer />
+			</div>
+		);
 	}
 
 	return (
@@ -181,6 +192,7 @@ export default function MapPage() {
 							canGoNext={xbdSelector.canGoNext}
 							onPrev={xbdSelector.goPrev}
 							onNext={xbdSelector.goNext}
+							chatCommand={chatCommand}
 						/>
 					</div>
 					<div className="xl:col-span-3 h-[80vh]">
@@ -198,7 +210,6 @@ export default function MapPage() {
 					</div>
 				</div>
 			</div>
-			<DisasterResponseAssistant />
 			<Footer />
 		</div>
 	);

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -13,9 +13,13 @@ import { getDisasterIdByName } from "@/utils/hazardlyApi.ts";
 
 interface MapPageProps {
 	chatCommand?: ChatMapCommand | null;
+	highlightResetToken?: number;
 }
 
-export default function MapPage({ chatCommand = null }: MapPageProps) {
+export default function MapPage({
+	chatCommand = null,
+	highlightResetToken = 0,
+}: MapPageProps) {
 	const { disaster_name, xbdid } = useParams<{
 		disaster_name: string;
 		xbdid: string;
@@ -201,6 +205,7 @@ export default function MapPage({ chatCommand = null }: MapPageProps) {
 							onPrev={xbdSelector.goPrev}
 							onNext={xbdSelector.goNext}
 							chatCommand={chatCommand}
+							highlightResetToken={highlightResetToken}
 						/>
 					</div>
 					<div className="xl:col-span-3 h-[80vh]">

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -43,6 +43,7 @@ export default function MapPage({ chatCommand = null }: MapPageProps) {
 	const parsedXbdId =
 		isXbdMissing || isXbdMalformed ? 18 : Number(normalizedXbdId);
 	const [selectedXbdId, setSelectedXbdId] = useState(parsedXbdId);
+	const lastAppliedChatSceneIdRef = useRef<string | null>(null);
 
 	useEffect(() => {
 		setSelectedXbdId(parsedXbdId);
@@ -140,9 +141,16 @@ export default function MapPage({ chatCommand = null }: MapPageProps) {
 	);
 
 	useEffect(() => {
-		if (chatCommand?.targetXbdId && chatCommand.targetXbdId !== selectedXbdId) {
+		if (!chatCommand?.targetXbdId) {
+			return;
+		}
+		if (lastAppliedChatSceneIdRef.current === chatCommand.id) {
+			return;
+		}
+		if (chatCommand.targetXbdId !== selectedXbdId) {
 			setSelectedXbdId(chatCommand.targetXbdId);
 		}
+		lastAppliedChatSceneIdRef.current = chatCommand.id;
 	}, [chatCommand, selectedXbdId]);
 
 	const disasterId = resolvedDisasterId ?? 1;

--- a/frontend/src/pages/dashboard/DashboardBuildingsSection.tsx
+++ b/frontend/src/pages/dashboard/DashboardBuildingsSection.tsx
@@ -1,5 +1,5 @@
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/Button";
 import ImagePreviewDialog from "@/components/ui/ImagePreviewDialog";
@@ -58,6 +58,61 @@ type PreviewImage = {
 
 const resolveStorageUrl = (path?: string | null): string | null =>
 	path ? resolveImageUrl(path) : null;
+
+function AddressCopyButton({ address }: { address: string }) {
+	const [copied, setCopied] = useState(false);
+	const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (copyTimerRef.current !== null) {
+				clearTimeout(copyTimerRef.current);
+			}
+		};
+	}, []);
+
+	const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		try {
+			await navigator.clipboard.writeText(address);
+			setCopied(true);
+			if (copyTimerRef.current !== null) {
+				clearTimeout(copyTimerRef.current);
+			}
+			copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
+		} catch (error) {
+			console.error("Failed to copy address:", error);
+		}
+	};
+
+	return (
+		<button
+			className="copy-btn"
+			onClick={handleCopy}
+			aria-label="Copy address"
+			type="button"
+			title={copied ? "Copied" : "Copy address"}
+		>
+			<svg
+				className={`copy-icon ${copied ? "copied" : ""}`}
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+			>
+				<title>{copied ? "Copied" : "Copy to clipboard"}</title>
+				{copied ? (
+					<polyline points="20 6 9 17 4 12" />
+				) : (
+					<>
+						<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+					</>
+				)}
+			</svg>
+		</button>
+	);
+}
 
 export default function DashboardBuildingsSection({
 	totalItems,
@@ -269,6 +324,11 @@ export default function DashboardBuildingsSection({
 													imageAlt={`Building ${building.uid}`}
 													title={building.address || building.uid}
 													subtitle={building.address ? building.uid : undefined}
+													titleAccessory={
+														building.address ? (
+															<AddressCopyButton address={building.address} />
+														) : undefined
+													}
 													imageOverlayLabel="Preview"
 													imageButtonLabel={`Preview building ${building.uid}`}
 													onImageClick={() => {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -50,6 +50,7 @@ export interface ChatMessage {
 	id: string;
 	role: "fieldUser" | "responseAssistant";
 	content: string;
+	isPending?: boolean;
 	mapCommandSummary?: string;
 	suggestedActionLabel?: string;
 	actionPayload?: ChatResponse;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,0 +1,56 @@
+export interface ChatFocus {
+	lat: number;
+	lon: number;
+	address?: string;
+}
+
+export interface ChatHighlightedBuilding {
+	id?: string;
+	uid: string;
+	xbd_id?: number | null;
+	damage?: string;
+	geometry?: GeoJSON.Geometry;
+}
+
+export interface ChatAction {
+	type?: string;
+	target?: string | null;
+	reason?: string;
+	url?: string | null;
+	params?: {
+		disaster_name?: string;
+		xbd_id?: number | null;
+		building_uid?: string;
+		building_ids?: string[];
+		lat?: number;
+		lon?: number;
+		address?: string;
+		damage?: string;
+	};
+}
+
+export interface ChatResponse {
+	answer: string;
+	response?: string;
+	focus: ChatFocus | null;
+	highlighted_buildings: ChatHighlightedBuilding[];
+	action?: ChatAction;
+}
+
+export interface ChatMapCommand {
+	id: string;
+	focus: ChatFocus | null;
+	highlightedBuildingIds: string[];
+	highlightedBuildingGeometries: GeoJSON.Geometry[];
+	targetXbdId?: number | null;
+	targetBuildingUid?: string | null;
+}
+
+export interface ChatMessage {
+	id: string;
+	role: "fieldUser" | "responseAssistant";
+	content: string;
+	mapCommandSummary?: string;
+	suggestedActionLabel?: string;
+	actionPayload?: ChatResponse;
+}

--- a/frontend/src/utils/addBuildingLayer.ts
+++ b/frontend/src/utils/addBuildingLayer.ts
@@ -9,6 +9,7 @@ export const BUILDINGS_OUTLINE_LAYER_ID = "buildings-outline";
 const DAMAGE_DEFAULT_HEX = "#ccc";
 const OUTLINE_COLOR_DEFAULT = "#ffffff";
 const OUTLINE_COLOR_SELECTED = "#ffdf00";
+const OUTLINE_COLOR_HIGHLIGHTED = "#38bdf8";
 
 export function getBuildingDamageColor(damage?: string): string {
 	if (damage == null || damage === "") return DAMAGE_DEFAULT_HEX;
@@ -52,12 +53,12 @@ export function addBuildingLayer(map: MapboxMap, geojson: FeatureCollection) {
 				],
 				"fill-opacity": [
 					"case",
-					[
-						"any",
-						["boolean", ["feature-state", "hover"], false],
-						["boolean", ["feature-state", "selected"], false],
-					],
-					0.7,
+					["boolean", ["feature-state", "selected"], false],
+					0.78,
+					["boolean", ["feature-state", "highlighted"], false],
+					0.68,
+					["any", ["boolean", ["feature-state", "hover"], false]],
+					0.56,
 					0.4,
 				],
 			},
@@ -75,16 +76,18 @@ export function addBuildingLayer(map: MapboxMap, geojson: FeatureCollection) {
 					"case",
 					["boolean", ["feature-state", "selected"], false],
 					OUTLINE_COLOR_SELECTED,
+					["boolean", ["feature-state", "highlighted"], false],
+					OUTLINE_COLOR_HIGHLIGHTED,
 					OUTLINE_COLOR_DEFAULT,
 				],
 				"line-width": [
 					"case",
-					[
-						"any",
-						["boolean", ["feature-state", "hover"], false],
-						["boolean", ["feature-state", "selected"], false],
-					],
+					["boolean", ["feature-state", "selected"], false],
 					3.5,
+					["boolean", ["feature-state", "highlighted"], false],
+					3,
+					["any", ["boolean", ["feature-state", "hover"], false]],
+					2.5,
 					1.5,
 				],
 			},

--- a/frontend/src/utils/chatNavigation.ts
+++ b/frontend/src/utils/chatNavigation.ts
@@ -1,0 +1,100 @@
+import type {
+	ChatAction,
+	ChatHighlightedBuilding,
+	ChatMapCommand,
+	ChatResponse,
+} from "@/types/chat";
+
+const getResolvedTargetXbdId = (
+	action: ChatAction | undefined,
+	buildings: ChatHighlightedBuilding[],
+): number | null => {
+	if (typeof action?.params?.xbd_id === "number") {
+		return action.params.xbd_id;
+	}
+
+	const counts = new Map<number, number>();
+	for (const building of buildings) {
+		if (typeof building.xbd_id !== "number") continue;
+		counts.set(building.xbd_id, (counts.get(building.xbd_id) ?? 0) + 1);
+	}
+
+	let bestXbdId: number | null = null;
+	let bestCount = -1;
+	for (const [xbdId, count] of counts.entries()) {
+		if (count > bestCount) {
+			bestXbdId = xbdId;
+			bestCount = count;
+		}
+	}
+
+	return bestXbdId;
+};
+
+export const buildChatNavigationUrl = (
+	response: ChatResponse,
+): string | null => {
+	if (response.action?.url) {
+		return response.action.url;
+	}
+
+	const disasterName = response.action?.params?.disaster_name?.trim();
+	const targetXbdId = getResolvedTargetXbdId(
+		response.action,
+		response.highlighted_buildings,
+	);
+	const buildingUid = response.action?.params?.building_uid?.trim();
+
+	if (!disasterName) {
+		return null;
+	}
+
+	const basePath =
+		typeof targetXbdId === "number"
+			? `/map/${encodeURIComponent(disasterName)}/${encodeURIComponent(String(targetXbdId))}`
+			: `/map/${encodeURIComponent(disasterName)}`;
+
+	if (!buildingUid || typeof targetXbdId !== "number") {
+		return basePath;
+	}
+
+	return `${basePath}?building=${encodeURIComponent(buildingUid)}`;
+};
+
+export const buildChatCommand = (response: ChatResponse): ChatMapCommand => {
+	const targetXbdId = getResolvedTargetXbdId(
+		response.action,
+		response.highlighted_buildings,
+	);
+	const buildingsForScene =
+		typeof targetXbdId === "number"
+			? response.highlighted_buildings.filter(
+					(building) => building.xbd_id === targetXbdId,
+				)
+			: response.highlighted_buildings;
+
+	const highlightedBuildingIds = buildingsForScene
+		.map((building) => building.uid?.trim())
+		.filter((uid): uid is string => Boolean(uid));
+	const highlightedBuildingGeometries = buildingsForScene
+		.map((building) => building.geometry)
+		.filter((geometry): geometry is GeoJSON.Geometry => geometry !== undefined);
+	const actionBuildingUid =
+		response.action?.params?.building_uid?.trim() ?? null;
+	const targetBuildingUid =
+		actionBuildingUid &&
+		buildingsForScene.some((building) => building.uid === actionBuildingUid)
+			? actionBuildingUid
+			: buildingsForScene.length === 1
+				? (buildingsForScene[0]?.uid?.trim() ?? null)
+				: null;
+
+	return {
+		id: crypto.randomUUID(),
+		focus: response.focus,
+		highlightedBuildingIds,
+		highlightedBuildingGeometries,
+		targetXbdId,
+		targetBuildingUid,
+	};
+};

--- a/frontend/src/utils/hazardlyApi.ts
+++ b/frontend/src/utils/hazardlyApi.ts
@@ -12,6 +12,7 @@ const IMAGE_BASE_URL = import.meta.env.VITE_HAZARDLY_IMAGE_BASE_URL?.replace(
 	/\/$/,
 	"",
 );
+const API_FETCH_TIMEOUT_MS = 30000;
 
 const getRequiredApiBaseUrl = (): string => {
 	if (!API_BASE_URL) {
@@ -320,16 +321,50 @@ async function apiFetch<T>(
 	options?: ApiFetchOptions,
 	context?: string,
 ): Promise<T> {
-	const res = await fetch(`${getRequiredApiBaseUrl()}${path}`, {
-		signal: options?.signal,
-	});
-	if (!res.ok) {
-		const message = context
-			? `${context}: API error ${res.status} for ${path}: ${res.statusText}`
-			: `API error ${res.status} for ${path}: ${res.statusText}`;
-		throw new ApiError(message, res.status, path);
+	const controller = new AbortController();
+	const handleAbort = () => controller.abort();
+	const timeoutId = window.setTimeout(
+		() => controller.abort(),
+		API_FETCH_TIMEOUT_MS,
+	);
+
+	if (options?.signal) {
+		if (options.signal.aborted) {
+			controller.abort();
+		} else {
+			options.signal.addEventListener("abort", handleAbort, { once: true });
+		}
 	}
-	return (await res.json()) as T;
+
+	try {
+		const res = await fetch(`${getRequiredApiBaseUrl()}${path}`, {
+			signal: controller.signal,
+		});
+		if (!res.ok) {
+			const message = context
+				? `${context}: API error ${res.status} for ${path}: ${res.statusText}`
+				: `API error ${res.status} for ${path}: ${res.statusText}`;
+			throw new ApiError(message, res.status, path);
+		}
+		return (await res.json()) as T;
+	} catch (error) {
+		if (
+			error instanceof DOMException &&
+			error.name === "AbortError" &&
+			!options?.signal?.aborted
+		) {
+			const message = context
+				? `${context}: Request timed out after ${API_FETCH_TIMEOUT_MS / 1000}s`
+				: `Request timed out after ${API_FETCH_TIMEOUT_MS / 1000}s for ${path}`;
+			throw new Error(message);
+		}
+		throw error;
+	} finally {
+		window.clearTimeout(timeoutId);
+		if (options?.signal) {
+			options.signal.removeEventListener("abort", handleAbort);
+		}
+	}
 }
 
 // ─── Public API functions ────────────────────────────────────────────────────

--- a/frontend/src/utils/mapViewSetup.ts
+++ b/frontend/src/utils/mapViewSetup.ts
@@ -489,16 +489,7 @@ export function setHighlightedBuildingsByUid(params: {
 }): number {
 	const { beforeMap, afterMap, uids, highlightedBuildingIdsRef } = params;
 
-	for (const featureId of highlightedBuildingIdsRef.current) {
-		beforeMap.setFeatureState(
-			{ source: BUILDINGS_SOURCE_ID, id: featureId },
-			{ highlighted: false },
-		);
-		afterMap.setFeatureState(
-			{ source: BUILDINGS_SOURCE_ID, id: featureId },
-			{ highlighted: false },
-		);
-	}
+	clearHighlightedBuildings({ beforeMap, afterMap, highlightedBuildingIdsRef });
 
 	const nextFeatureIds: Array<string | number> = [];
 	const seenFeatureIds = new Set<string | number>();
@@ -528,4 +519,25 @@ export function setHighlightedBuildingsByUid(params: {
 
 	highlightedBuildingIdsRef.current = nextFeatureIds;
 	return nextFeatureIds.length;
+}
+
+export function clearHighlightedBuildings(params: {
+	beforeMap: mapboxgl.Map;
+	afterMap: mapboxgl.Map;
+	highlightedBuildingIdsRef: MutableRefObject<Array<string | number>>;
+}) {
+	const { beforeMap, afterMap, highlightedBuildingIdsRef } = params;
+
+	for (const featureId of highlightedBuildingIdsRef.current) {
+		beforeMap.setFeatureState(
+			{ source: BUILDINGS_SOURCE_ID, id: featureId },
+			{ highlighted: false },
+		);
+		afterMap.setFeatureState(
+			{ source: BUILDINGS_SOURCE_ID, id: featureId },
+			{ highlighted: false },
+		);
+	}
+
+	highlightedBuildingIdsRef.current = [];
 }

--- a/frontend/src/utils/mapViewSetup.ts
+++ b/frontend/src/utils/mapViewSetup.ts
@@ -480,3 +480,51 @@ export function createCompareInstance(params: {
 
 	return compare;
 }
+
+export function setHighlightedBuildingsByUid(params: {
+	beforeMap: mapboxgl.Map;
+	afterMap: mapboxgl.Map;
+	uids: string[];
+	highlightedBuildingIdsRef: MutableRefObject<Array<string | number>>;
+}) {
+	const { beforeMap, afterMap, uids, highlightedBuildingIdsRef } = params;
+
+	for (const featureId of highlightedBuildingIdsRef.current) {
+		beforeMap.setFeatureState(
+			{ source: BUILDINGS_SOURCE_ID, id: featureId },
+			{ highlighted: false },
+		);
+		afterMap.setFeatureState(
+			{ source: BUILDINGS_SOURCE_ID, id: featureId },
+			{ highlighted: false },
+		);
+	}
+
+	const nextFeatureIds: Array<string | number> = [];
+	const seenFeatureIds = new Set<string | number>();
+
+	for (const uid of uids) {
+		const features = beforeMap.querySourceFeatures(BUILDINGS_SOURCE_ID, {
+			filter: ["==", ["get", "uid"], uid],
+		});
+
+		for (const feature of features) {
+			if (typeof feature.id !== "string" && typeof feature.id !== "number") {
+				continue;
+			}
+			if (seenFeatureIds.has(feature.id)) continue;
+			seenFeatureIds.add(feature.id);
+			nextFeatureIds.push(feature.id);
+			beforeMap.setFeatureState(
+				{ source: BUILDINGS_SOURCE_ID, id: feature.id },
+				{ highlighted: true },
+			);
+			afterMap.setFeatureState(
+				{ source: BUILDINGS_SOURCE_ID, id: feature.id },
+				{ highlighted: true },
+			);
+		}
+	}
+
+	highlightedBuildingIdsRef.current = nextFeatureIds;
+}

--- a/frontend/src/utils/mapViewSetup.ts
+++ b/frontend/src/utils/mapViewSetup.ts
@@ -486,7 +486,7 @@ export function setHighlightedBuildingsByUid(params: {
 	afterMap: mapboxgl.Map;
 	uids: string[];
 	highlightedBuildingIdsRef: MutableRefObject<Array<string | number>>;
-}) {
+}): number {
 	const { beforeMap, afterMap, uids, highlightedBuildingIdsRef } = params;
 
 	for (const featureId of highlightedBuildingIdsRef.current) {
@@ -527,4 +527,5 @@ export function setHighlightedBuildingsByUid(params: {
 	}
 
 	highlightedBuildingIdsRef.current = nextFeatureIds;
+	return nextFeatureIds.length;
 }


### PR DESCRIPTION
Implements backend support for #40 chatbot-driven routing.

Adds routing/action payload support to chatbot responses:
- answer/response for chatbot text
- focus with lat/lon/address
- highlighted_buildings with id, uid, xbd_id, damage, geometry
- action payload with route target and URL for frontend navigation

Updates building queries to join image_pairs so the backend can return xbd_id for frontend routes like:
/map/:disasterName/:xbd_id?building=:buildingUid

Tested with:
“How many major damaged buildings are near Houston?”

Confirmed response includes:
- action.type = navigate
- action.target = map
- action.url = /map/hurricane-harvey/18
- highlighted_buildings include uid as string and xbd_id